### PR TITLE
Add an endpoint to list images from a patient name

### DIFF
--- a/plugin_tests/tcga_test.py
+++ b/plugin_tests/tcga_test.py
@@ -862,6 +862,13 @@ class TCGARestTest(BaseTest, base.TestCase):
         )
 
         resp = self.request(
+            path='/tcga/image',
+            params={'caseName': self.case1['name']}
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['data']), 2)
+
+        resp = self.request(
             path='/tcga/image/' + image1
         )
         self.assertStatusOk(resp)


### PR DESCRIPTION
Adds an endpoint as follows: `/api/v1/tcga/image?caseName=<case name>`.  This will return a list of images associated with the given case (patient).  This is returns the same information as the existing endpoint `/api/v1/tcga/case/<case id>/images`, but uses the label name rather than the mongo id.