### PR TITLE
Add an item/query endpoint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
     - large_image_path=$girder_path/plugins/large_image
     - git clone https://github.com/DigitalSlideArchive/large_image.git $large_image_path && git -C $large_image_path checkout $LARGE_IMAGE_VERSION
 
-    - export MONGO_VERSION=3.2.8
+    - export MONGO_VERSION=3.4.19
     - export PY_COVG="ON"
     - CACHE=$HOME/.cache source $girder_path/scripts/install_mongo.sh
     - mkdir /tmp/db


### PR DESCRIPTION
This adds a simple `GET item/query` endpoint that takes limit, offset, sort, and query parameters.  query is a JSON-encoded mongo query performed on items.  For instance, to find all the XTK items, query could be `json.dumps({'meta.XTK': {'$exists': True}})`.  Only items the current user can read are returned.  If you use a sort that doesn't have an index in the database, the query could fail due to Mongo's in-memory sort limit.