### PR TITLE
Add a test for the docker-compose file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,33 @@ jobs:
       - run:
           name: Ensure that we can run tests
           command: docker exec histomicstk_histomicstk bash -lc 'tox -e flake8,lintclient'
+  docker-compose:
+    working_directory: ~/project
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Run docker-compose up
+          command: bash -c 'CURRENT_UID=$(id -u):$(id -g) docker-compose up -d'
+          working_directory: ./devops/dsa
+      - run:
+          name: Update modules
+          command: pip install -U pip requests
+      - run:
+          name: Install modules needed for testing
+          command: pip install girder-client
+      - run:
+          name: Wait for girder to respond and be configured
+          command: |
+            for f in `seq 60`; do if curl --silent http://localhost:8080/api/v1/system/version | grep 'release'; then break; fi; sleep 1; done
+            for f in `seq 60`; do if curl --silent 'http://localhost:8080/api/v1/folder?text=Slicer%20CLI%20Web%20Tasks' | grep 'Tasks'; then break; fi; sleep 1; done
+      - run:
+          name: Grant permissions to docker socket.
+          # This is better done by adding the user in the docker container to the group, but that complicates the docker-compose example.
+          command: sudo chmod a+xwr /var/run/docker.sock
+      - run:
+          name: Test the instance
+          command: python ansible/utils/cli_test.py dsarchive/histomicstk:latest --user=admin --password=password --test
   publish-docker:
     working_directory: ~/project
     machine: true
@@ -219,6 +246,13 @@ workflows:
       - test-lint:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
+      - docker-compose:
           filters:
             tags:
               only: /^v.*/

--- a/devops/dsa/Dockerfile
+++ b/devops/dsa/Dockerfile
@@ -8,6 +8,9 @@ ENV GDAL_PAM_PROXY_DIR=/tmp/gdal
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
 
+# Yarn breaks their deployment once a year.  We don't use yarn.  Just remove it.
+RUN rm /etc/apt/sources.list.d/yarn.list
+
 # Install libfuse.  This allows better access to files on S3
 RUN apt-get update && \
     apt-get install -y fuse && \
@@ -27,8 +30,8 @@ RUN pip install --pre --no-cache-dir \
     large_image_tasks[girder,worker] \
     # girder[mount] adds dependencies to show tiles from S3 assets \
     girder[mount] \
-    # You could add additional girder plugins here (e.g.,
-    # girder-virtual-folders or girder-dicom-viewer)
+    # You could add additional girder plugins here (e.g., \
+    # girder-virtual-folders or girder-dicom-viewer) \
     # Use prebuilt wheels whenever possible \
     --find-links https://girder.github.io/large_image_wheels
 
@@ -41,6 +44,6 @@ COPY worker.local.cfg /usr/local/lib/python3.7/site-packages/girder_worker/worke
 
 # Build the girder web client
 RUN girder build && \
-    # Git rid of unnecessary files to keep the docker image smaller
+    # Git rid of unnecessary files to keep the docker image smaller \
     find /usr/local/lib/python3.7 -name node_modules -exec rm -rf {} \+ && \
     rm -rf /tmp/npm*

--- a/devops/dsa/girder_config.py
+++ b/devops/dsa/girder_config.py
@@ -23,6 +23,9 @@ Setting().set('worker.api_url', 'http://girder:8080/api/v1')
 if User().findOne() is None:
     User().createUser('admin', 'password', 'Admin', 'Admin', 'admin@nowhere.nil')
 adminUser = User().findOne({'admin': True})
+# Make sure we have an assetstore
+if Assetstore().findOne() is None:
+    Assetstore().createFilesystemAssetstore('Assetstore', '/assetstore')
 # If we don't have a default task folder, make a task collection and folder
 if not Setting().get('slicer_cli_web.task_folder'):
     # Make sure we have a Tasks collection with a Slicer CLI Web Tasks folder
@@ -36,6 +39,3 @@ if not Setting().get('slicer_cli_web.task_folder'):
             public=True, creator=adminUser)
     taskFolder = Folder().findOne({'name': taskFolderName, 'parentId': tasksCollection['_id']})
     Setting().set('slicer_cli_web.task_folder', str(taskFolder['_id']))
-# Make sure we have an assetstore
-if Assetstore().findOne() is None:
-    Assetstore().createFilesystemAssetstore('Assetstore', '/assetstore')


### PR DESCRIPTION
Also, fix yarn breaking packages.  Yarn rotates a key annually; this makes it so apt-get update fails.  Since we don't use yarn, just remove the apt sources for it.