### PR TITLE
Improve restart girder scripts.

### DIFF
--- a/ansible/roles/girder/templates/rebuild_and_restart_girder.sh.j2
+++ b/ansible/roles/girder/templates/rebuild_and_restart_girder.sh.j2
@@ -2,10 +2,11 @@
 
 set -e
 
+OLDSTART=$(curl --silent 'http://127.0.0.1:8080/api/v1/system/version')
 girder build --dev
 sudo touch /home/{{ girder_exec_user }}/.girder/girder.cfg
 echo "Girder has been rebuilt and will now restart"
-while true; do curl --silent 'http://127.0.0.1:8080/api/v1/system/version' | grep -q 'release' && break || true; sleep 1; echo -n "."; done
+while true; do NEWSTART=$(curl --silent 'http://127.0.0.1:8080/api/v1/system/version' || true); if [ "${OLDSTART}" != "${NEWSTART}" ]; then echo ${NEWSTART} | grep -q 'release' && break || true; fi; sleep 1; echo -n "."; done
 echo ""
 echo "Girder has restarted"
 

--- a/ansible/roles/girder/templates/restart_girder.sh.j2
+++ b/ansible/roles/girder/templates/restart_girder.sh.j2
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
+OLDSTART=$(curl --silent 'http://127.0.0.1:8080/api/v1/system/version')
 sudo touch /home/{{ girder_exec_user }}/.girder/girder.cfg
 echo "Girder will now restart"
-while true; do curl --silent 'http://127.0.0.1:8080/api/v1/system/version' | grep -q 'release' && break || true; sleep 1; echo -n "."; done
+while true; do NEWSTART=$(curl --silent 'http://127.0.0.1:8080/api/v1/system/version' || true); if [ "${OLDSTART}" != "${NEWSTART}" ]; then echo ${NEWSTART} | grep -q 'release' && break || true; fi; sleep 1; echo -n "."; done
 echo ""
 echo "Girder has restarted"
 


### PR DESCRIPTION
Before, in some instances, the script would end before the restart had happened.  Now, it should wait until the restart is complete.