### PR TITLE
Rebuild the girder web client when a proxy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,18 +73,15 @@ jobs:
           name: Start nginx
           command: |
             sudo apt-get install nginx
-            sudo cp .circleci/proxy.nginx /etc/nginx/sites-available/default
+            sudo cp .circleci/dsa_proxy.nginx /etc/nginx/sites-available/default
             sudo service nginx restart
       - run:
           name: Start containers
-          command: export TERM=xterm && python ansible/deploy_docker.py start --cfg=.circleci/proxy.cfg
-      - run:
-          name: Rebuild and restart girder
-          command: docker exec dsa_girder bash -lc 'rebuild_and_restart_girder.sh'
+          command: export TERM=xterm && python ansible/deploy_docker.py start --cfg=.circleci/dsa_proxy.cfg
       - run:
           name: "Wait for girder to be available"
           command: |
-            for f in `seq 120`; do curl --silent 'http://127.0.0.1/girder/api/v1/system/version' | tac | tac | grep -q 'release' && break; sleep 1; done
+            for f in `seq 120`; do curl --silent 'http://127.0.0.1/dsa/api/v1/system/version' | tac | tac | grep -q 'release' && break; sleep 1; done
       - run:
           name: "Check that we can read from the api and static assets in the proxy path locations"
           # grep -q will close its connection as soon as it finds a match, but
@@ -92,12 +89,12 @@ jobs:
           # program that reads the entire contents avoids this problem.
           # grepping unquietly first does this.
           command: |
-            curl --silent 'http://127.0.0.1/girder/'
-            curl --silent 'http://127.0.0.1/girder/api/v1/system/version'
-            curl --silent 'http://127.0.0.1/girder/static/built/plugins/large_image/extra/geojs.js' | head || true
-            curl --silent 'http://127.0.0.1/girder/' | grep '/girder/static/built/plugins/large_image' | grep -q '/girder/static/built/plugins/large_image' && echo 'correct references'
-            curl --silent 'http://127.0.0.1/girder/api/v1/system/version' | grep 'release' | grep -q 'release' && echo 'reports version'
-            curl --silent 'http://127.0.0.1/girder/static/built/plugins/large_image/extra/geojs.js' | grep 'createRenderer' | grep -q 'createRenderer' && echo 'can reach geojs'
+            curl --silent 'http://127.0.0.1/dsa/'
+            curl --silent 'http://127.0.0.1/dsa/api/v1/system/version'
+            curl --silent 'http://127.0.0.1/dsa/static/built/plugins/large_image/extra/geojs.js' | head || true
+            curl --silent 'http://127.0.0.1/dsa/' | grep '/dsa/static/built/plugins/large_image' | grep -q '/dsa/static/built/plugins/large_image' && echo 'correct references'
+            curl --silent 'http://127.0.0.1/dsa/api/v1/system/version' | grep 'release' | grep -q 'release' && echo 'reports version'
+            curl --silent 'http://127.0.0.1/dsa/static/built/plugins/large_image/extra/geojs.js' | grep 'createRenderer' | grep -q 'createRenderer' && echo 'can reach geojs'
       - run:
           name: Show Girder logs to allow easier review
           command: |

--- a/.circleci/dsa_proxy.cfg
+++ b/.circleci/dsa_proxy.cfg
@@ -1,0 +1,6 @@
+[global]
+tools.proxy.on = True
+
+[server]
+api_root = "/dsa/api/v1"
+static_public_path = "/dsa/static"

--- a/.circleci/dsa_proxy.nginx
+++ b/.circleci/dsa_proxy.nginx
@@ -10,7 +10,7 @@ server {
   location / {
     try_files $uri $uri/ =404;
   }
-  location /girder/ {
+  location /dsa/ {
     proxy_set_header Host $proxy_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;

--- a/.circleci/proxy.cfg
+++ b/.circleci/proxy.cfg
@@ -1,6 +1,0 @@
-[global]
-tools.proxy.on = True
-
-[server]
-api_root = "/girder/api/v1"
-static_public_path = "/girder/static"

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -116,3 +116,27 @@ Inside the vagrant box, tests can be run by typing::
     cd /opt/HistomicsUI
     tox
 
+Docker and Reverse Proxy
+------------------------
+
+One common deployment is to install the Digital Slide Archive via docker and expose it as a subdirectory on another web host via a reverse proxy.  For instance, instead of having the Digital Slide Archive be reached at ``http://myserver.com:8080``, you can have it reachable at ``http://myserver.com/dsa/``.  To do this, a webserver is needed to provide the reverse proxy redirection, and some additional configuration needs to be specified as part of the provisioning of the docker containers.
+
+Follow the guide for `Girder Reverse Proxy <https://girder.readthedocs.io/en/latest/deploy.html#reverse-proxy>`_ to configure Apache or nginx appropriately.
+
+Create a local configuration file that can be passed to the ``deploy_docker.py`` script.  For instance, save the following as a file called ``dsa_proxy.cfg``::
+
+    [global]
+    tools.proxy.on = True
+
+    [server]
+    api_root = "/dsa/api/v1"
+    static_public_path = "/dsa/static"
+
+Now, when you issue the ``deploy_docker.py start`` command, specify the custom configuration file::
+
+    python deploy_docker.py start --cfg=dsa_proxy.cfg
+
+You'll need to specify the ``--cfg`` option whenever the ``start`` command used, including when updating an existing installation.
+
+    Note:
+        If you change the path of the reverse proxy on a running instance, you'll need to change the config file internal to the docker Girder container and rebuild and restart Girder within the docker.  This is in addition to restarting Apache or nginx as appropriate.

--- a/ansible/roles/provision/tasks/main.yml
+++ b/ansible/roles/provision/tasks/main.yml
@@ -12,6 +12,11 @@
   retries: 300
   when: docker is defined
 
+- name: Rebuild girder if the static_public_path is not the default.
+  shell: "if $(grep static_public_path /home/{{ girder_exec_user }}/.girder/girder.cfg | grep -v '\"/static\"'); then rebuild_and_restart_girder.sh; fi"
+  args:
+    executable: /bin/bash
+
 - name: Reinstall HistomicsUI - in development deployments this can be necessary
   pip:
     name: /opt/HistomicsUI


### PR DESCRIPTION
As part of provisioning, rebuild girder if the static_piblic_path isn't the default.

Add some documentation about reverse proxy.