### PR TITLE
Updated instructions to fix docker permissions…

### DIFF
--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -25,7 +25,9 @@ The current user needs to be a member of the docker group::
 
     sudo usermod -aG docker `id -u -n`
 
-After which, you will need to log out and log back in.
+After which, you will need re-evaluate group membership::
+
+    newgrp docker
 
 Install the python docker module::
 


### PR DESCRIPTION
Issue with running docker as a standard user where they did not have the permissions if the user quickly logged out and back in through the Ubuntu GUI.  The session isn't properly reset and the group permissions aren't re-evaluated.  This seems to be based on how long the user has been logged out.  [Docker Documentation](https://docs.docker.com/install/linux/linux-postinstall/) contains an alternative which is running the "newgrp docker" command. 