### PR TITLE
Exposed built dockers as circle-ci artifacts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ jobs:
           paths:
             - ./dsa_girder.tar
             - ./dsa_worker.tar
+      - store_artifacts:
+          path: ./dsa_girder.tar
+      - store_artifacts:
+          path: ./dsa_worker.tar
   test-cli:
     working_directory: ~/project
     machine: true


### PR DESCRIPTION
This will allow downloading the tarballs and installing them locally via a command like `docker load -i dsa_girder.tar`.