### PR TITLE
Update the README files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,11 @@ For local development including HistomicsUI, there are some `devops <./devops>`_
 
 There is a `migration guide <./ansible/migration.rst>`_  from the Girder 2 version.
 
+Adding Docker Tasks
+-------------------
+
+Docker tasks conforming to the `slicer_cli_web <https://github.com/girder/slicer_cli_web>`_ module's requirements can be added.  These tasks appear in the HistomicsUI interface and in the Girder interface.  An administrator can add a Docker image by going to the slicer_cli_web plugin settings and entering the Docker image name there.  For instance, to get the HistomicsTK tasks, add ``dsarchive/histomicstk:latest``.
+
 Funding
 -------
 This work is funded in part by the `NIH grant U24-CA194362-01 <http://grantome.com/grant/NIH/U24-CA194362-01>`_.

--- a/devops/README.rst
+++ b/devops/README.rst
@@ -8,13 +8,23 @@ Description
 This folder contains a set of scripts that are convenient to develop
 Digital Slide Archive and HistomicsUI inside its docker container.
 
-The following environment variable need to be defined for these scripts
-to run:
+The following environment variables can be defined to affect how these scripts
+run:
 
-* ``HISTOMICS_TESTDATA_FOLDER``: Folder in which the test data will be installed
-  on the host computer. This allows one to not download the test data every time,
-  but instead keep it directly on the host computer. If the container is removed,
-  there is no need to download the data again.
+* ``HISTOMICS_TESTDATA_FOLDER``: Folder where test data will be located on the
+  host computer.  Data from this folder can be imported into a filesystem
+  assetstore from the ``/data`` directory.  This defaults to 
+  ``~/.histomics_data`` if that directory is present.
+
+* ``HISTOMICS_SOURCE_FOLDER``: If the HistomicsUI repository is available 
+  locally, it is mounted into the running docker container to make development
+  easier.  This defaults to a directory located at ``../../HistomicsUI`` in 
+  relation to this README file.
+
+* ``SLICER_CLI_WEB_SOURCE_FOLDER``: If the slicer_cli_web repository is 
+  available locally, it is mounted into the running docker container to make
+  development easier.  This defaults to a directory located at 
+  ``../../slicer_cli_web`` in relation to this README file.
 
 Scripts
 =======


### PR DESCRIPTION
The main README now mentions how to add Docker tasks.  The devops README has been updated to reflect recent changes.