### PR TITLE
Improve how vagrant makes the initial disk.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,18 +15,21 @@ Vagrant.configure("2") do |config|
     v.name = "Digital Slide Archive Ubuntu 18.04"
     # You may need to configure this to run benignly on your host machine
     v.memory = 4096
-    v.cpus = 4
+    v.cpus = 2
     # Size the disk to a specific number of Mbytes.
     if Vagrant.has_plugin?("vagrant-disksize")
       config.disksize.size = "100GB"
+      config.vm.provision "ResizeStep", type: "shell", inline: <<-SHELL
+        sudo parted /dev/sda resizepart 1 100%
+        sudo pvresize /dev/sda1
+        sudo lvresize -rl +100%FREE /dev/mapper/vagrant--vg-root
+      SHELL
     end
-  end
-
-  provisioner_type = "ansible_local"
-  config.vm.provision provisioner_type do |ansible|
-    ansible.playbook = "ansible/vagrant.yml"
-    ansible.galaxy_role_file = "ansible/requirements.yml"
-    ansible.provisioning_path = "/vagrant"
-    ansible.install_mode = "pip"
+    config.vm.provision "AnsibleStep", type: "ansible_local" do |ansible|
+      ansible.playbook = "ansible/vagrant.yml"
+      ansible.galaxy_role_file = "ansible/requirements.yml"
+      ansible.provisioning_path = "/vagrant"
+      ansible.install_mode = "pip"
+    end
   end
 end


### PR DESCRIPTION
If the vagrant-disksize plugin is available, properly resize the default disk.