### PR TITLE
By default, don't build the website in dev mode.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       - startcontainers
       - run:
           name: Ensure that we can rebuild girder
-          command: docker exec dsa_girder bash -lc 'girder build --dev'
+          command: docker exec dsa_girder bash -lc 'girder build'
       - run:
           name: Check number of files owned by ubuntu user in girder container
           command: |

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -175,11 +175,18 @@
     virtualenv: "{{ girder_virtualenv }}"
     state: present
 
+- name: Avoid bad versions of virtualenv
+  pip:
+    name:
+      - virtualenv!=20.0.11,!=20.0.12
+    virtualenv: "{{ girder_virtualenv }}"
+    state: present
+
 - name: Build girder
   environment:
     - LC_ALL: "C.UTF-8"
     - LANG: "C.UTF-8"
-  command: "{{ girder_virtualenv }}/bin/girder build --dev"
+  command: "{{ girder_virtualenv }}/bin/girder build"
 
 - name: Link the root directory to an old location
   file:

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -37,7 +37,7 @@
   post_tasks:
     - name: Ensure we can rebuild the girder web client
       shell: >-
-        bash -lc "girder build --dev >/tmp/test_build.txt 2>&1"
+        bash -lc "girder build >/tmp/test_build.txt 2>&1"
       become: true
       become_user: "{{ girder_exec_user }}"
 

--- a/devops/build.sh
+++ b/devops/build.sh
@@ -6,4 +6,5 @@
 
 var="$(echo $@)"
 
+# We build in dev mode to get source maps on the client
 docker exec -it dsa_girder bash -lc "girder build --dev $var"


### PR DESCRIPTION
The devops tools still do, since it is expected you want dev mode in development.

This doesn't affect the girder python mode.