### PR TITLE
Fix parameter escaping in devops scripts.

### DIFF
--- a/devops/build.sh
+++ b/devops/build.sh
@@ -4,7 +4,7 @@
 #   --watch-plugin histomicsui
 # to the command line.
 
-var="$(echo $@)"
+var="$@"
 
 # We build in dev mode to get source maps on the client
-docker exec -it dsa_girder bash -lc "girder build --dev $var"
+docker exec -it dsa_girder bash -lc "girder build --dev \"$var\""

--- a/devops/test.sh
+++ b/devops/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-var="$(echo $@)"
+var="$@"
 
-docker exec -it dsa_girder bash -lc "tox $var"
+docker exec -it dsa_girder bash -lc "tox \"$var\""


### PR DESCRIPTION
Before, something like `test.sh -e lintclient` wouldn't work because of how parameters were escaped.