### PR TITLE
Fix bash parameter escaping as passed to docker.

### DIFF
--- a/devops/build.sh
+++ b/devops/build.sh
@@ -4,7 +4,9 @@
 #   --watch-plugin histomicsui
 # to the command line.
 
-var="$@"
+# @@Q quotes each parameter.  echo forms a single string that can be added to 
+# a command without further quoting.
+var=$(echo "${@@Q}")
 
 # We build in dev mode to get source maps on the client
-docker exec -it dsa_girder bash -lc "girder build --dev \"$var\""
+docker exec -it dsa_girder bash -lc "girder build --dev $var"

--- a/devops/test.sh
+++ b/devops/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-var="$@"
+# @@Q quotes each parameter.  echo forms a single string that can be added to 
+# a command without further quoting.
+var=$(echo "${@@Q}")
 
-docker exec -it dsa_girder bash -lc "tox \"$var\""
+docker exec -it dsa_girder bash -lc "tox $var"
+


### PR DESCRIPTION
In order to preserve whitespace in parameters, this uses some arcane bash operations.  There is probably a better way to do it, but this works in various tests.