### PR TITLE
Add options for specifying config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ _build*
 .vagrant
 ansible/roles/girder.girder
 ansible/roles/girder.mongodb
-ansible/sample.cfg
+ansible/sample*.cfg

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -396,6 +396,10 @@ def container_start_rabbitmq(
             if rmqport:
                 params['ports'] = [5672]
                 config['port_bindings'] = {5672: int(rmqport)}
+            if kwargs.get('rmqconf'):
+                config['binds'] = [
+                    kwargs['rmqconf'] + ':/etc/rabbitmq/rabbitmq.conf:ro',
+                ]
             print('Creating %s - %s' % (image, name))
             ctn = client.create_container(
                 host_config=client.create_host_config(**config),
@@ -442,6 +446,11 @@ def container_start_worker(client, env, key='worker', rmq='docker', **kwargs):
             ],
         }
         config['binds'].extend(docker_mounts())
+        if kwargs.get('workerconf'):
+            config['binds'] = [
+                kwargs['workerconf'] +
+                ':/usr/local/lib/python3.7/site-packages/girder_worker/worker.local.cfg:ro',
+            ]
         config_mounts(kwargs.get('mount'), config)
         if rmq == 'docker':
             config['links'][ImageList['rabbitmq']['name']] = 'rabbitmq'
@@ -990,6 +999,9 @@ if __name__ == '__main__':   # noqa
         help='Either use rabbitmq from docker or from host (docker, host, or '
         'IP adress or hostname of host.')
     parser.add_argument(
+        '--rmqconf', '--rmqcfg',
+        help='Mount a local file as /etc/rabbitmq/rabbitmq.conf.')
+    parser.add_argument(
         '--status', '-s', action='store_true',
         help='Report the status of relevant docker containers and images.')
     parser.add_argument(
@@ -1005,6 +1017,10 @@ if __name__ == '__main__':   # noqa
         help='The path to use for the girder_worker tmp_root.  This must be '
         'reachable by the girder and worker docker containers.  It cannot be '
         'a top-level directory.')
+    parser.add_argument(
+        '--workerconf', '--workercfg',
+        help='Mount a local file as /usr/local/lib/python3.7/site-packages/'
+        'girder_worker/worker.local.cfg.')
     parser.add_argument('--verbose', '-v', action='count', default=0)
 
     # Should we add an optional url or host value for rmq and mongo?

--- a/ansible/roles/common/set_environment.py
+++ b/ansible/roles/common/set_environment.py
@@ -131,8 +131,8 @@ def set_hosts():
         else:
             import socket
             rmqhost = socket.gethostbyname(rmqhost)
-        if 'rmq' not in [line.split()[-1] for line in hosts]:
-            hosts.append('%s rmq' % rmqhost)
+        if 'rabbitmq' not in [line.split()[-1] for line in hosts]:
+            hosts.append('%s rabbitmq' % rmqhost)
             changed = True
     hosts.append('%s dockerhost' % hostip)
     changed = True

--- a/devops/dsa/worker.local.cfg
+++ b/devops/dsa/worker.local.cfg
@@ -1,6 +1,6 @@
 [celery]
 app_main=girder_worker
-broker=amqp://guest@rabbitmq/
+broker=amqp://guest:guest@rabbitmq/
 
 [girder_worker]
 


### PR DESCRIPTION
Allow overriding rabbitmq and girder worker config files.  This allows using non-guest rabbitmq users.