### PR TITLE
Fix docker-compose testing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,9 @@ jobs:
           command: pip install -U pip requests
       - run:
           name: Install modules needed for testing
-          command: pip install girder-client
+          # diskcache<5 is requried for Python 2.7.  It would probably be
+          # better to install python3 in this container.
+          command: pip install girder-client 'diskcache<5'
       - run:
           name: Wait for girder to respond and be configured
           command: |

--- a/devops/dsa/Dockerfile
+++ b/devops/dsa/Dockerfile
@@ -21,6 +21,8 @@ RUN mkdir -p /fuse --mode=a+rwx
 
 # By using --no-cache-dir the Docker image is smaller
 RUN pip install --pre --no-cache-dir \
+    # We don't work with the beta of celery 5
+    'celery<5' \
     # histomicui installs all of our absolutely required packages \
     histomicsui \
     # large_image[all] adds all tile sources and memcached support \


### PR DESCRIPTION
The default machine has Python 2.  An upstream package is mislabeled for Python 2 and doesn't work properly.