### PR TITLE
Use the rpc backend to stop celery warnings.

### DIFF
--- a/ansible/roles/girder/templates/worker.local.cfg.j2
+++ b/ansible/roles/girder/templates/worker.local.cfg.j2
@@ -1,6 +1,7 @@
 [celery]
 app_main=girder_worker
 broker=amqp://guest:guest@{{ mq_private_ip }}/
+backend=rpc://guest:guest@{{ mq_private_ip }}/
 
 [girder_worker]
 

--- a/ansible/roles/provision/tasks/main.yml
+++ b/ansible/roles/provision/tasks/main.yml
@@ -127,7 +127,7 @@
       path: system/setting
       parameters:
         key: worker.backend
-        value: "amqp://guest:guest@{{ mq_private_ip }}/"
+        value: "rpc://guest:guest@{{ mq_private_ip }}/"
 
 - name: Set worker api url setting
   girder:

--- a/ansible/roles/worker/templates/worker.local.cfg.j2
+++ b/ansible/roles/worker/templates/worker.local.cfg.j2
@@ -1,6 +1,7 @@
 [celery]
 app_main=girder_worker
 broker=amqp://guest:guest@{{ mq_private_ip }}/
+backend=rpc://guest:guest@{{ mq_private_ip }}/
 
 [girder_worker]
 

--- a/devops/dsa/girder_config.py
+++ b/devops/dsa/girder_config.py
@@ -16,7 +16,7 @@ configureServer()
 
 # Ensure worker settings are correct
 Setting().set('worker.broker', 'amqp://guest:guest@rabbitmq/')
-Setting().set('worker.backend', 'amqp://guest:guest@rabbitmq/')
+Setting().set('worker.backend', 'rpc://guest:guest@rabbitmq/')
 Setting().set('worker.api_url', 'http://girder:8080/api/v1')
 
 # If there is are no users, create an admin user


### PR DESCRIPTION
We don't do anything with the celery backend, so this change makes no changes other than reducing warnings.