### PR TITLE
Increase the memcached max-item-size.

### DIFF
--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -285,7 +285,11 @@ def container_start_memcached(client, env, key='memcached', memcached='docker', 
             }
             params = {
                 'image': image,
-                'command': ['memcached', '-m', str(kwargs.get('cache', 1024))],
+                'command': [
+                    'memcached',
+                    '-m', str(kwargs.get('cache', 1024)),
+                    '--max-item-size', '8M',
+                ],
                 'detach': True,
                 'hostname': key,
                 'name': name,

--- a/devops/dsa/docker-compose.yml
+++ b/devops/dsa/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     #   - "27017"
   memcached:
     image: memcached
-    command: -m 4096
+    command: -m 4096 --max-item-size 8M
     restart: unless-stopped
     # Uncomment to allow access to memcached from outside of the docker network
     # ports:


### PR DESCRIPTION
For 1024 x 1024 tiles, 4MB are often necessary.  Allow up to 8MB.