### PR TITLE
Fix the minimal docker-compose example.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,26 @@ jobs:
       - run:
           name: Test the instance
           command: python devops/dsa/utils/cli_test.py dsarchive/histomicstk:latest --user=admin --password=password --test
+  docker-compose-minimal:
+    working_directory: ~/project
+    machine:
+      image: ubuntu-2004:202111-02
+    steps:
+      - checkout
+      - run:
+          name: Use Python 3.9
+          command: |
+            pyenv versions
+            pyenv global 3.9.7
+            pip --version
+      - run:
+          name: Run docker-compose up
+          command: docker-compose up --build -d
+          working_directory: ./devops/minimal
+      - run:
+          name: Wait for girder to respond and be configured
+          command: |
+            for f in `seq 60`; do if curl --silent http://localhost:8080/api/v1/system/version | grep 'release'; then break; fi; sleep 1; done
   publish-docker:
     working_directory: ~/project
     machine:
@@ -320,6 +340,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - docker-compose-minimal:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - publish-docker:
           requires:
             - test-cli
@@ -366,6 +393,7 @@ workflows:
           requires:
             - build
       - docker-compose
+      - docker-compose-minimal
       - docs
       - publish-docker:
           requires:

--- a/devops/dsa/provision.py
+++ b/devops/dsa/provision.py
@@ -47,7 +47,11 @@ def get_sample_data(adminUser, collName='Sample Images', folderName='Images'):
     :param folderName: the folder name where the data will bed aded.
     :returns: the folder where the sample data is located.
     """
-    import girder_client
+    try:
+        import girder_client
+    except ImportError:
+        logger.error('girder_client is unavailable.  Cannot get sample data.')
+        return
     from girder_large_image.models.image_item import ImageItem
 
     folder = get_collection_folder(adminUser, collName, folderName)

--- a/devops/minimal/Dockerfile
+++ b/devops/minimal/Dockerfile
@@ -17,6 +17,9 @@ RUN pip install \
     histomicsui \
     large_image[sources] \
     girder-homepage \
+    # girder-client is used to get sample data.  If you don't fetch sample \
+    # data, it isn't necessary \
+    girder-client \
     --find-links https://girder.github.io/large_image_wheels
 
 RUN girder build


### PR DESCRIPTION
The minimal docker-compose example failed on importing data because it requires girder-client.

Fixes #191.