### PR TITLE
Support provisioning additional girder plugins.

### DIFF
--- a/devops/dsa/.gitignore
+++ b/devops/dsa/.gitignore
@@ -1,3 +1,4 @@
 assetstore/
 db/
 logs/
+*.local.*

--- a/devops/dsa/README.rst
+++ b/devops/dsa/README.rst
@@ -97,3 +97,48 @@ Permissions
 -----------
 
 By default, the girder container is run in Docker privileged mode.  This can be reduced to a small set of permissions (see the docker-compose.yml file for details), but these may vary depending on the host system.  If no extra permissions are granted, or if the docker daemon is started with --no-new-privileges, or if libfuse is not installed on the host system, the internal fuse mount will not be started.  This may prevent full functionality with non-filesystem assestores and with some multiple-file image formats.
+
+Customizing
+-----------
+
+Since this uses standard docker-compose, you can customize the process by creating a ``docker-compose.overide.yml`` file in the same directory (or a yaml file of any name and use appropriate ``docker-compose -f docker-compose.yml -f <my yaml file> <command>`` command).  Further, if you mount a provisioning yaml file into the docker image, you can customize settings, plugins, resources, and other options.
+
+See the ``docker-compose.yml`` and ``provision.yaml`` files for details. 
+
+Example
+~~~~~~~
+
+To add some additional girder plugins and mount additional directories for assetstores, you can do something like this:
+
+``docker-compose.overide.yml``::
+
+    ---
+    version: '3'
+    services:
+      girder:
+        environment:
+          # Specify that we want to use the provisioning file
+          DSA_PROVISION_YAML: ${DSA_PROVISION_YAML:-/opt/digital_slide_archive/devops/dsa/provision.yaml}
+        volumes:
+          # Mount the local provisioning file into the container
+          - ./provision.local.yaml:/opt/digital_slide_archive/devops/dsa/provision.yaml
+          # Also expose a local data mount into the container
+          - /mnt/data:/mnt/data
+
+``provision.local.yaml``::
+
+    ---
+    # Load some sample data
+    samples: True
+    # A list of additional pip modules to install
+    pip:
+      - girder-oauth
+      - girder-ldap
+    # rebuild the girder web client since we installe some additional plugins
+    rebuild-client: True
+    # List slicer-cli-images to pull and load
+    slicer-cli-image:
+      - dsarchive/histomicstk:latest
+      - girder/slicer_cli_web:small
+
+

--- a/devops/dsa/docker-compose.yml
+++ b/devops/dsa/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # but these may be somewhat host specific, so we default to privileged.  If
     # the docker daemon is being run with --no-new-privileges, fuse may not
     # work.
-    # See also https://github.com/docker/for-linux/issues/321 for possible 
+    # See also https://github.com/docker/for-linux/issues/321 for possible
     # methods to avoid both privileged mode and cap_add SYS_ADMIN.
     privileged: true
     # Set DSA_USER to a user id that is part of the docker group (e.g.,

--- a/devops/dsa/girder.cfg
+++ b/devops/dsa/girder.cfg
@@ -32,7 +32,7 @@ cache_memcached_password = None
 #  These can be used to reduce the amount of memory used for caching tile
 #  sources
 # cache_tilesource_memory_portion = 16
-# cache_tilesource_maximum = 64
+cache_tilesource_maximum = 64
 
 [cache]
 enabled = True

--- a/devops/dsa/provision.yaml
+++ b/devops/dsa/provision.yaml
@@ -5,6 +5,19 @@ force: False
 samples: False
 sample-collection: Sample Images
 sample-folder: Images
+# Set use_defaults to False to skip default settings
+use_defaults: True
+# Set mongo_compat to False to not automatically set the mongo feature
+# compatibility version to the current server version.
+mongo_compat: True
+# A list of additional pip modules to install; if any are girder plugins with
+# client-side code, also specify rebuild-client.
+# pip:
+#   - girder-oauth
+#   - girder-ldap
+# rebuild-client may be False, True (for dev mode), or "production"
+rebuild-client: False
+# Default admin user if there are no admin users
 admin:
   login: admin
   password: password
@@ -12,10 +25,17 @@ admin:
   lastName: Admin
   email: admin@nowhere.nil
   public: True
+# Default assetstore if there are no assetstores
 assetstore:
   method: createFilesystemAssetstore
   name: Assetstore
   root: /assetstore
+# Any resources to ensure exist.  A model must be specified.  This creates the
+# resource if there is no match for all specified values.  A value of
+# "resource:<path>" is converted to the resource document with that resource
+# path.  "resource:admin" uses the default admin, "resourceid:<path>" is the
+# string id for the resource path, and "resourceid:admin" is the string if for
+# default admin.
 resources:
   - model: collection
     name: Tasks
@@ -48,3 +68,6 @@ settings:
 
     The [HistomicsUI](histomics) application is enabled.
   slicer_cli_web.task_folder: "resourceid:collection/Tasks/Slicer CLI Web Tasks"
+# List slicer-cli-images to pull and load
+# slicer-cli-image:
+#   - dsarchive/histomicstk:latest

--- a/devops/dsa/start_girder.sh
+++ b/devops/dsa/start_girder.sh
@@ -22,6 +22,10 @@ sysctl -w net.ipv4.conf.eth0.route_localnet=1
 iptables -t nat -A OUTPUT -o lo -p tcp -m tcp --dport 27017 -j DNAT --to-destination `dig +short mongodb`:27017
 iptables -t nat -A OUTPUT -o lo -p tcp -m tcp --dport 11211 -j DNAT --to-destination `dig +short memcached`:11211
 iptables -t nat -A POSTROUTING -o eth0 -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE
+echo 'PATH="/opt/digital_slide_archive/devops/dsa/utils:/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH"' >> /home/$(id -nu ${DSA_USER%%:*})/.bashrc
+echo ==== Pre-Provisioning === 
+PATH="/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH" \
+python /opt/digital_slide_archive/devops/dsa/provision.py -v --pre 
 # Run subsequent commands as the DSA_USER.  This sets some paths based on what
 # is expected in the Docker so that the current python environment and the
 # devops/dsa/utils are available.  Then:
@@ -34,10 +38,10 @@ iptables -t nat -A POSTROUTING -o eth0 -m addrtype --src-type LOCAL --dst-type U
 # - Start the main girder process.
 su $(id -nu ${DSA_USER%%:*}) -c "
   PATH=\"/opt/digital_slide_archive/devops/dsa/utils:/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH\";
-  echo ==== Provisioning ===
-  python /opt/digital_slide_archive/devops/dsa/provision.py -v &&
-  echo ==== Creating FUSE mount ===
+  echo ==== Provisioning === &&
+  python /opt/digital_slide_archive/devops/dsa/provision.py -v --main &&
+  echo ==== Creating FUSE mount === &&
   (girder mount /fuse || true) &&
-  echo ==== Starting Girder ===
+  echo ==== Starting Girder === &&
   girder serve --dev
 "


### PR DESCRIPTION
Modify the provisioning script to make it easier to install additional pip modules.  This allows rebuilding the girder client after such installation. 

Also, install the dsarchive/histomicstk:latest cli by default.