### PR TITLE
Install docker-cli inside the common docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,4 +13,5 @@ ansible/sample*.cfg
 devops/dsa/assetstore
 devops/dsa/db
 devops/dsa/logs
+devops/singularity-minimal
 !**/.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,26 @@ RUN apt-get update && \
     # Needed for su command
     # sudo \
     && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    find / -xdev -name '*.py[oc]' -type f -exec rm {} \+ && \
+    find / -xdev -name __pycache__ -type d -exec rm -r {} \+
+
+# Install docker command line tools.  If docker is unavailable, this will do no
+# harm.  If the host system isn't ubuntu, this should still allow debug.
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null && \
+    ls -al /etc/apt/sources.list.d && \
+    cat /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    docker-ce-cli \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    find / -xdev -name '*.py[oc]' -type f -exec rm {} \+ && \
+    find / -xdev -name __pycache__ -type d -exec rm -r {} \+
 
 RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /usr/bin/tini && \
     chmod +x /usr/bin/tini

--- a/devops/dsa/docker-compose.yml
+++ b/devops/dsa/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - "${DSA_PORT:-8080}:8080"
     volumes:
       # Needed to use slicer_cli_web to run docker containers
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
       # Default assetstore
       - ./assetstore:/assetstore
@@ -146,7 +145,6 @@ services:
     restart: unless-stopped
     volumes:
       # Needed to use slicer_cli_web to run docker containers
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
       # Allow overriding the start command
       - ./start_worker.sh:/opt/digital_slide_archive/devops/dsa/start_worker.sh


### PR DESCRIPTION
The external docker executable might not be compatible with the internal environment.  This ensures it still can be used for debug.