### PR TITLE
Set the DIVE install to use the main branch of the repo

### DIFF
--- a/devops/with-dive-volview/provision.divevolview.yaml
+++ b/devops/with-dive-volview/provision.divevolview.yaml
@@ -1,7 +1,7 @@
 ---
 pip:
   - git+https://github.com/PaulHax/girder_volview
-  - git+https://github.com/BryonLewis/dive-dsa.git@dsa-install#subdirectory=server
+  - git+https://github.com/BryonLewis/dive-dsa.git#subdirectory=server
 rebuild-client: True
 settings:
   worker.broker: "amqp://guest:guest@rabbitmq"
@@ -13,6 +13,6 @@ slicer-cli-image:
   - dsarchive/histomicstk:latest
 worker:
   pip:
-    - git+https://github.com/BryonLewis/dive-dsa.git@dsa-install#subdirectory=server
+    - git+https://github.com/BryonLewis/dive-dsa.git#subdirectory=server
   shell:
     - wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && mkdir /tmp/ffextracted && tar -xvf ffmpeg.tar.xz -C /tmp/ffextracted --strip-components 1 && cp /tmp/ffextracted/ffmpeg /opt/venv/bin && cp /tmp/ffextracted/ffprobe /opt/venv/bin && rm -rf /tmp/ffextracted


### PR DESCRIPTION
Just modifying the install of dive to use the main branch.

I've set up some CI for publishing the new releases of the DIVE client as well as building my own docker images used for testing on the main branch now.

I have set my local install to this and built/tested it to make sure it is updating properly.