### PR TITLE
Fix ansible build.

### DIFF
--- a/ansible/roles/worker/tasks/main.yml
+++ b/ansible/roles/worker/tasks/main.yml
@@ -93,7 +93,7 @@
     executable: pip3
     chdir: /opt/large_image
     extra_args: "--find-links https://girder.github.io/large_image_wheels"
-    requirements: "requirements-worker.txt"
+    requirements: "requirements-dev.txt"
     state: present
 
 - name: Clone slicer_cli_web


### PR DESCRIPTION
There was a requirements file in large image that wasn't used by that project but was used here.  When it was removed from large_image, it broke the ansible build.