### PR TITLE
Improve starting on OSX.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
           command: pip3 install -U pip
       - run:
           name: Install dependencies
-          command: pip3 install requests docker
+          command: pip3 install requests docker 'urllib3<2'
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -25,7 +25,7 @@ commands:
           command: pip3 install -U pip
       - run:
           name: Install dependencies
-          command: pip3 install requests docker
+          command: pip3 install requests docker 'urllib3<2'
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -50,7 +50,7 @@ jobs:
           command: pip3 install -U pip
       - run:
           name: Install dependencies
-          command: pip3 install ansible requests docker six
+          command: pip3 install ansible requests docker six 'urllib3<2'
       - run:
           name: Build the dockers
           command: export TERM=xterm && python3 ansible/deploy_docker.py build
@@ -212,7 +212,7 @@ jobs:
           path: ./dsa_common.tar
       - run:
           name: Update modules
-          command: pip install -U pip requests
+          command: pip install -U pip requests 'urllib3<2'
       - run:
           name: Install modules needed for testing
           command: pip install girder-client six

--- a/devops/dsa/README.rst
+++ b/devops/dsa/README.rst
@@ -54,7 +54,7 @@ Sample data can be added after performing ``docker-compose up`` by running::
 
     python utils/cli_test.py dsarchive/histomicstk:latest --test
 
-This downloads the HistomicsTK analysis tools, some sample data, and runs nuclei detection on some of the sample data.
+This downloads the HistomicsTK analysis tools, some sample data, and runs nuclei detection on some of the sample data.  You need Python 3.6 or later available and may need to ``pip install girder-client`` before you can run this command.
 
 
 Development

--- a/devops/dsa/start_girder.sh
+++ b/devops/dsa/start_girder.sh
@@ -16,6 +16,9 @@ adduser $(id -nu ${DSA_USER%%:*}) $(getent group ${DSA_USER#*:} | cut "-d:" -f1)
 addgroup --gid $(stat -c "%g" /var/run/docker.sock) docker 2>/dev/null
 # add the user to the docker group.
 adduser $(id -nu ${DSA_USER%%:*}) $(getent group $(stat -c "%g" /var/run/docker.sock) | cut "-d:" -f1) 2>/dev/null
+# Try to increase permissions for the docker socket; this helps this work on
+# OSX where the users don't translate
+chmod 777 /var/run/docker.sock 2>/dev/null || true
 # Use iptables to make some services appear as if they are on localhost (as
 # well as on the docker network).  This is done to allow tox tests to run.
 sysctl -w net.ipv4.conf.eth0.route_localnet=1

--- a/devops/dsa/start_worker.sh
+++ b/devops/dsa/start_worker.sh
@@ -16,6 +16,9 @@ adduser $(id -nu ${DSA_USER%%:*}) $(getent group ${DSA_USER#*:} | cut "-d:" -f1)
 addgroup --gid $(stat -c "%g" /var/run/docker.sock) docker 2>/dev/null
 # add the user to the docker group.
 adduser $(id -nu ${DSA_USER%%:*}) $(getent group $(stat -c "%g" /var/run/docker.sock) | cut "-d:" -f1) 2>/dev/null
+# Try to increase permissions for the docker socket; this helps this work on
+# OSX where the users don't translate
+chmod 777 /var/run/docker.sock 2>/dev/null || true
 chmod 777 ${TMPDIR:-/tmp} || true
 echo ==== Pre-Provisioning ===
 python3 /opt/digital_slide_archive/devops/dsa/provision.py --worker-pre

--- a/devops/dsa/utils/cli_test.py
+++ b/devops/dsa/utils/cli_test.py
@@ -8,7 +8,6 @@ import tempfile
 import time
 
 import girder_client
-import six
 
 
 def get_girder_client(opts):
@@ -23,7 +22,7 @@ def get_girder_client(opts):
     username = opts.get('username')
     password = opts.get('password')
     if not username and not token:
-        username = six.moves.input('Admin login: ')
+        username = input('Admin login: ')
     if not password and not token:
         password = getpass.getpass('Password for %s: ' % (
             username if username else 'default admin user'))


### PR DESCRIPTION
The permissions needed for /var/run/docker.sock on OSX are different than on linux.