### PR TITLE
Remove the dicom viewer plugin.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,9 +93,9 @@ RUN cd /opt && \
     pip install --no-cache-dir -e .[analysis]
 
 # Install additional girder plugins
-RUN pip install --no-cache-dir --pre \
-    girder-archive-access \
-    girder-dicom-viewer \
+RUN pip install --no-cache-dir \
+    # girder-archive-access \
+    # girder-dicom-viewer \
     girder-homepage \
     girder-ldap \
     girder-resource-path-tools \

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -179,8 +179,10 @@
 - name: Install Girder plugins
   pip:
     name:
-      - girder-archive-access
-      - girder-dicom-viewer
+      # girder-archive-access and girder-dicom-viewer use a library that has
+      # issues
+      # - girder-archive-access
+      # - girder-dicom-viewer
       - girder-homepage
       - girder-ldap
       - girder-resource-path-tools


### PR DESCRIPTION
The girder dicom viewer and archive access plugin both require a javascript library (Daikon) where the most recent version (1.2.45) has dependencies that cause conflicts with the large_image viewer.

To resolve this, either dependencies in Girder plugins need to be pinned or the library that has an issue needs another update.