### PR TITLE
Mongo 7 upgrade

### DIFF
--- a/devops/dsa/provision.py
+++ b/devops/dsa/provision.py
@@ -615,9 +615,13 @@ if __name__ == '__main__':  # noqa
                 logger.warning('Could not connect to mongo.')
             try:
                 db.admin.command({'setFeatureCompatibilityVersion': '.'.join(
-                    db.server_info()['version'].split('.')[:2])})
+                    db.server_info()['version'].split('.')[:2]), 'confirm': True})
             except Exception:
-                logger.warning('Could not set mongo feature compatibility version.')
+                try:
+                    db.admin.command({'setFeatureCompatibilityVersion': '.'.join(
+                        db.server_info()['version'].split('.')[:2])})
+                except Exception:
+                    logger.warning('Could not set mongo feature compatibility version.')
             try:
                 # Also attempt to upgrade old version 2 image sources
                 db.girder.item.update_many(

--- a/devops/minimal/provision.py
+++ b/devops/minimal/provision.py
@@ -615,9 +615,13 @@ if __name__ == '__main__':  # noqa
                 logger.warning('Could not connect to mongo.')
             try:
                 db.admin.command({'setFeatureCompatibilityVersion': '.'.join(
-                    db.server_info()['version'].split('.')[:2])})
+                    db.server_info()['version'].split('.')[:2]), 'confirm': True})
             except Exception:
-                logger.warning('Could not set mongo feature compatibility version.')
+                try:
+                    db.admin.command({'setFeatureCompatibilityVersion': '.'.join(
+                        db.server_info()['version'].split('.')[:2])})
+                except Exception:
+                    logger.warning('Could not set mongo feature compatibility version.')
             try:
                 # Also attempt to upgrade old version 2 image sources
                 db.girder.item.update_many(


### PR DESCRIPTION
This change improves compatibility with upgrading to newer mongo versions.

As part of our provisioning, we automatically ask mongo to upgrade the feature compatibility version.  This means that if you upgrade the DSA deployment using standard methods, it automatically upgrades your Mongo database as you go.  In theory, should one ever need to go back, you could downgrade the mongodb version manually a step at a time.  In practice, I'm not sure any deployments downgrade mongo.

As of Mongo 7, you can no longer undo upgrades to the DB.  The upgrade process requires an additional parameter because of this, so we aren't currently (2023-08-18) upgrade the feature compatibility version.  This will lead to problems on the next mongo release.

We have a flag in the provisioning (`mongo-compat`) that, if False, we skip the compatibility version adjustment.

The actual downgrade path is probably to do a mongodump, remove the mongo database, start with an older version of mongo, and do a mongorestore.