### PR TITLE
Set default python to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /
     chmod +x /usr/bin/tini
 
 # Make a virtualenv with our preferred python
-RUN virtualenv --python 3.11 /opt/venv
+RUN virtualenv --python 3.9 /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Make sure core packages are up to date


### PR DESCRIPTION
This had been the case before a recent change, and it turns out some downstream packages depend on <3.10 (specifically the dive integration).