### PR TITLE
Keep deprecated deployment working for now

### DIFF
--- a/ansible/Dockerfile-girder
+++ b/ansible/Dockerfile-girder
@@ -89,12 +89,13 @@ RUN sudo apt-get update && \
     && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN curl --silent https://bootstrap.pypa.io/get-pip.py -O && \
-    python3.7 get-pip.py && \
     python3.8 get-pip.py && \
     python3.9 get-pip.py && \
     python3.10 get-pip.py && \
     curl --silent https://bootstrap.pypa.io/pip/3.6/get-pip.py -O && \
     python3.6 get-pip.py && \
+    curl --silent https://bootstrap.pypa.io/pip/3.7/get-pip.py -O && \
+    python3.7 get-pip.py && \
     rm get-pip.py && \
     sudo find / -xdev -name '*.py[oc]' -type f -exec rm {} \+ && \
     sudo find / -xdev -name __pycache__ -type d -exec rm -r {} \+


### PR DESCRIPTION
It will be discontinued once the deprecation message is a year old nd any other maintenance is needed (no earlier than July 2024).