### PR TITLE
Mark the common docker with version information

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,8 +280,19 @@ jobs:
             diff /tmp/defaults.yaml /tmp/provfile.yaml && true
             if [[ $(diff /tmp/defaults.yaml /tmp/provfile.yaml | tail -n '+5') ]]; then false; fi
       - run:
+          name: Run docker compose build
+          command: bash -c 'DSA_USER=$(id -u):$(id -g) docker compose build'
+          working_directory: ./devops/dsa
+      - run:
+          name: Rebuild with version information
+          command: |
+            export DSA_VERSIONS=$(docker run --rm -it --entrypoint bash dsarchive/dsa_common -c 'python -c "import importlib.metadata,json,sys;sys.stdout.write(json.dumps({k: importlib.metadata.version(k).split(\"+\")[0] for k in [\"girder\",\"histomicsui\",\"large_image\",\"girder_worker\",\"girder_worker_utils\",\"girder_slicer_cli_web\",\"import_tracker\"]}))"' | grep -o '{.*}')
+            echo $DSA_VERSIONS
+            DSA_USER=$(id -u):$(id -g) docker compose build
+          working_directory: ./devops/dsa
+      - run:
           name: Run docker compose up
-          command: bash -c 'DSA_USER=$(id -u):$(id -g) docker compose up --build -d'
+          command: bash -c 'DSA_USER=$(id -u):$(id -g) docker compose up -d'
           working_directory: ./devops/dsa
       - run:
           name: Archive docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,9 @@ RUN cp /opt/digital_slide_archive/devops/dsa/utils/.vimrc ~/.vimrc && \
     cp /opt/digital_slide_archive/devops/dsa/girder.cfg /etc/girder.cfg && \
     cp /opt/digital_slide_archive/devops/dsa/worker.local.cfg /opt/girder_worker/girder_worker/.
 
+ARG DSA_VERSIONS
+ENV DSA_VERSIONS="$DSA_VERSIONS"
+
 # Better shutdown signalling
 ENTRYPOINT ["/usr/bin/tini", "--"]
 

--- a/devops/dsa/docker-compose.yml
+++ b/devops/dsa/docker-compose.yml
@@ -3,7 +3,11 @@ version: '3'
 services:
   girder:
     image: dsarchive/dsa_common
-    build: ../..
+    build:
+        context: ../..
+        # We use this to optionally set version information during the build
+        args:
+          DSA_VERSIONS: ${DSA_VERSIONS:-}
     # Instead of privileged mode, fuse can use:
     # devices:
     #   - /dev/fuse:/dev/fuse
@@ -141,7 +145,11 @@ services:
       retries: 3
   worker:
     image: dsarchive/dsa_common
-    build: ../..
+    build:
+        context: ../..
+        # We use this to optionally set version information during the build
+        args:
+          DSA_VERSIONS: ${DSA_VERSIONS:-}
     # Set DSA_USER to a user id that is part of the docker group (e.g.,
     # `DSA_USER=$(id -u):$(id -g)`).  This provides permissions to manage
     # docker


### PR DESCRIPTION
This appears as an ENV record in the docker history.  The actual entry is DSA_VERSIONS which is a json dictionary of the versions of some of the core libraries.