### PR TITLE
Remove duplicates from list of cli images to provision

### DIFF
--- a/devops/dsa/provision.py
+++ b/devops/dsa/provision.py
@@ -218,7 +218,8 @@ def get_slicer_images(imageList, adminUser, alwaysPull=False):
         job = Job().load(id=job['_id'], user=adminUser, includeLog=True)
         if 'log' in job:
             while logpos < len(job['log']):
-                logger.info(job['log'][logpos].rstrip())
+                if 'Pulling' not in job['log'][logpos] or '%' not in job['log'][logpos]:
+                    logger.info(job['log'][logpos].rstrip())
                 logpos += 1
     t.join()
     if 'log' not in job:
@@ -337,15 +338,19 @@ def provision(opts):  # noqa
             value = value_from_resource(value, adminUser)
             logger.info('Setting %s to %r', key, value)
             Setting().set(key, value)
+    images = []
     if getattr(opts, 'slicer-cli-image-pull', None):
+        images = list(dict.fromkeys(getattr(opts, 'slicer-cli-image-pull', None)))
         try:
             get_slicer_images(getattr(opts, 'slicer-cli-image-pull', None),
                               adminUser, alwaysPull=True)
         except Exception:
             logger.info('Cannot fetch slicer-cli-images.')
     if getattr(opts, 'slicer-cli-image', None):
+        images = [image for image in dict.fromkeys(getattr(opts, 'slicer-cli-image', None))
+                  if image not in images]
         try:
-            get_slicer_images(getattr(opts, 'slicer-cli-image', None), adminUser)
+            get_slicer_images(images, adminUser)
         except Exception:
             logger.info('Cannot fetch slicer-cli-images.')
 


### PR DESCRIPTION
If an image is listed in the always-pull section as well as the pull-as-needed section, it needlessly gets catalogued twice.  This prevents that.