### PR TITLE
Girder 5 docker and docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,21 @@ commands:
           name: Load archived common docker image
           command: |
             docker load -i /tmp/workspace/dsa_common.tar
+  usecommon5docker:
+    description: "Make built common docker available"
+    steps:
+      - run:
+          name: Upgrade pip
+          command: pip3 install -U pip
+      - run:
+          name: Install dependencies
+          command: pip3 install requests docker
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load archived common docker image
+          command: |
+            docker load -i /tmp/workspace/dsa_common_5.tar
   startcommon:
     description: Start containers for tests.
     steps:
@@ -225,6 +240,36 @@ jobs:
           name: Wait for girder to respond and be configured
           command: |
             for f in `seq 120`; do if curl --silent http://127.0.0.1:8080/api/v1/system/version | grep 'release'; then break; fi; sleep 1; done
+  docker-compose-girder-5:
+    working_directory: ~/project
+    machine:
+      image: ubuntu-2404:current
+    steps:
+      - checkout
+      - run:
+          name: Use Python 3.13
+          command: |
+            pyenv versions
+            pyenv global 3.13
+            pip --version
+      - run:
+          name: Run docker compose up
+          command: bash -c 'DSA_USER=$(id -u):$(id -g) docker compose up --build -d'
+          working_directory: ./devops/ver5
+      - run:
+          name: Wait for girder to respond and be configured
+          command: |
+            for f in `seq 120`; do if curl --silent http://127.0.0.1:8080/api/v1/system/version | grep 'release'; then break; fi; sleep 1; done
+      - run:
+          name: Archive docker images
+          command: |
+            docker save -o dsa_common_5.tar dsarchive/dsa_common_5:latest
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./dsa_common_5.tar
+      - store_artifacts:
+          path: ./dsa_common_5.tar
   publish-docker-common:
     working_directory: ~/project
     machine:
@@ -244,6 +289,25 @@ jobs:
               export DATE_TAG=`date '+%Y%m%d'`
               docker tag dsarchive/dsa_common:latest "dsarchive/dsa_common:$DATE_TAG"
               docker push "dsarchive/dsa_common:$DATE_TAG"
+  publish-docker-common5:
+    working_directory: ~/project
+    machine:
+      image: ubuntu-2404:current
+    steps:
+      - checkout
+      - usecommon5docker
+      - run:
+          name: Publish images to Docker Hub
+          command: |
+              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push dsarchive/dsa_common_5:latest
+              if [[ $CIRCLE_TAG =~ ^v.*$ ]]; then
+              docker tag dsarchive/dsa_common_5:latest "dsarchive/dsa_common_5:$CIRCLE_TAG"
+              docker push "dsarchive/dsa_common_5:$CIRCLE_TAG"
+              fi
+              export DATE_TAG=`date '+%Y%m%d'`
+              docker tag dsarchive/dsa_common_5:latest "dsarchive/dsa_common_5:$DATE_TAG"
+              docker push "dsarchive/dsa_common_5:$DATE_TAG"
   docs:
     docker:
       - image: cimg/ruby:3.3
@@ -351,6 +415,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - docker-compose-girder-5:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - docker-compose-external-worker:
           filters:
             tags:
@@ -375,6 +446,23 @@ workflows:
             - docker-compose-external-worker
             - docker-compose-with-dive-volview
             - scan-docker
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - master
+      - publish-docker-common5:
+          requires:
+            # - test-cli-common
+            # - test-girder-build-common
+            # - test-histomicsui-common
+            # - test-proxy-common
+            - docker-compose-girder-5
+            # - docker-compose-minimal
+            # - docker-compose-external-worker
+            # - docker-compose-with-dive-volview
+            # - scan-docker
           filters:
             tags:
               only: /^v.*/
@@ -416,6 +504,7 @@ workflows:
             - docker-compose
       - docker-compose-minimal
       - docker-compose-with-dive-volview
+      - docker-compose-girder-5
       - docker-compose-external-worker
       - scan-docker:
           requires:
@@ -429,3 +518,11 @@ workflows:
             - test-histomicsui-common
             - test-proxy-common
             - scan-docker
+      - publish-docker-common5:
+          requires:
+            - docker-compose-girder-5
+            # - test-cli-common
+            # - test-girder-build-common
+            # - test-histomicsui-common
+            # - test-proxy-common
+            # - scan-docker

--- a/devops/ver5/assetstore/.gitignore
+++ b/devops/ver5/assetstore/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/devops/ver5/db/.gitignore
+++ b/devops/ver5/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/devops/ver5/docker-compose.yml
+++ b/devops/ver5/docker-compose.yml
@@ -1,0 +1,198 @@
+---
+services:
+  girder:
+    image: dsarchive/dsa_common_5
+    build:
+      context: ../..
+      dockerfile: dsa5.Dockerfile
+      # We use this to optionally set version information during the build
+      args:
+        DSA_VERSIONS: ${DSA_VERSIONS:-}
+    # Instead of privileged mode, fuse can use:
+    # devices:
+    #   - /dev/fuse:/dev/fuse
+    # security_opt:
+    #   - apparmor:unconfined
+    # cap_add:
+    #   - SYS_ADMIN
+    # but these may be somewhat host specific, so we default to privileged.  If
+    # the docker daemon is being run with --no-new-privileges, fuse may not
+    # work.
+    # See also https://github.com/docker/for-linux/issues/321 for possible
+    # methods to avoid both privileged mode and cap_add SYS_ADMIN.
+    privileged: true
+    # Set DSA_USER to a user id that is part of the docker group (e.g.,
+    # `DSA_USER=$(id -u):$(id -g)`).  This makes files in assetstores and logs
+    # owned by that user and provides permissions to manage docker
+    environment:
+      DSA_USER: ${DSA_USER:-}
+      DSA_PROVISION_YAML: ${DSA_PROVISION_YAML:-/opt/digital_slide_archive/devops/dsa/provision.yaml}
+      CELERY_BROKER_URL: amqp://guest:guest@rabbitmq/
+      CELERY_RESULT_BACKEND: rpc://guest:guest@rabbitmq/
+      GIRDER_MONGO_URI: mongodb://mongodb:27017/girder?socketTimeoutMS=3600000
+      GIRDER_SERVER_MODE: production
+      GIRDER_SETTING_CORE_CACHE_ENABLED: true
+      GIRDER_SETTING_CORE_HTTP_ONLY_COOKIES: true
+      GIRDER_SETTING_SERVER_MODE: production
+      HISTOMICSUI_RESTRICT_DOWNLOADS: 100000
+      LARGE_IMAGE_CACHE_BACKEND: memcached
+      LARGE_IMAGE_CACHE_MEMCACHED_URL: memcached
+      LARGE_IMAGE_CACHE_MEMCACHED_PASSWORD: None
+      LARGE_IMAGE_CACHE_MEMCACHED_USERNAME: None
+      LARGE_IMAGE_CACHE_TILESOURCE_MAXIMUM: 64
+      # Mount options can be used to, for instance, add diskcache (e.g.,
+      #  "-o diskcache,diskcache_size_limit=2147483648")
+      DSA_GIRDER_MOUNT_OPTIONS: ${DSA_GIRDER_MOUNT_OPTIONS:-}
+      # You can also set girder settings here:
+      # GIRDER_SETTING_HISTOMICSUI_LOGIN_SESSION_EXPIRY_MINUTES: 15
+      # If you want to authorize docker image repositories on the host machine
+      # and have them accessed without further authorization within Girder,
+      # you can specify a docker config location, mount it (see volumes,
+      # below), and do "docker login <repo>" on the host machine before
+      # starting the DSA.
+      # DOCKER_CONFIG: /.docker
+    restart: unless-stopped
+    # Set DSA_PORT to expose the interface on another port (default 8080).
+    ports:
+      - "${DSA_PORT:-8080}:8080"
+    volumes:
+      # Needed to use slicer_cli_web to run docker containers
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Default assetstore
+      - ./assetstore:/assetstore
+      # Location of provision.py
+      - ./provision.py:/opt/digital_slide_archive/devops/dsa/provision.py
+      - ./provision.yaml:/opt/digital_slide_archive/devops/dsa/provision.yaml
+      - ./start_girder.sh:/opt/digital_slide_archive/devops/dsa/start_girder.sh
+      # Location to store logs
+      - ./logs:/logs
+    depends_on:
+      - mongodb
+      - memcached
+      - rabbitmq
+    command: /opt/digital_slide_archive/devops/dsa/start_girder.sh
+    # logging:
+    #   options:
+    #     max-size: "10M"
+    #     max-file: "5"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/system/version"]
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+  mongodb:
+    image: "mongo:latest"
+    # Set DSA_USER to your user id (e.g., `DSA_USER=$(id -u):$(id -g)`)
+    # so that database files are owned by yourself.
+    user: ${DSA_USER:-PLEASE SET DSA_USER}
+    restart: unless-stopped
+    # Limiting maxConns reduces the amount of shared memory demanded by
+    # mongo.  Remove this limit or increase the host vm.max_map_count value.
+    command: --maxConns 1000
+    volumes:
+      # Location to store database files
+      - ./db:/data/db
+    # Uncomment to allow access to the database from outside of the docker
+    # network.
+    # ports:
+    #   - "27017"
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+  memcached:
+    image: memcached
+    command: -m 4096 --max-item-size 8M
+    restart: unless-stopped
+    # Uncomment to allow access to memcached from outside of the docker network
+    # ports:
+    #   - "11211"
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"
+    healthcheck:
+      test: ["CMD", "bash", "-c", 'exec 3<>/dev/tcp/localhost/11211; printf "stats\nquit\n" >&3; cat <&3']
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+  rabbitmq:
+    image: "rabbitmq:latest"
+    restart: unless-stopped
+    # Uncomment to allow access to rabbitmq from outside of the docker network
+    # ports:
+    #   - "5672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-}
+    volumes:
+      - ./rabbitmq.advanced.config:/etc/rabbitmq/advanced.config:ro
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      retries: 3
+  worker:
+    image: dsarchive/dsa_common_5
+    build:
+      context: ../..
+      dockerfile: dsa5.Dockerfile
+      # We use this to optionally set version information during the build
+      args:
+        DSA_VERSIONS: ${DSA_VERSIONS:-}
+    # Set DSA_USER to a user id that is part of the docker group (e.g.,
+    # `DSA_USER=$(id -u):$(id -g)`).  This provides permissions to manage
+    # docker
+    environment:
+      DSA_USER: ${DSA_USER:-}
+      DSA_WORKER_CONCURRENCY: ${DSA_WORKER_CONCURRENCY:-2}
+      DSA_PROVISION_YAML: ${DSA_PROVISION_YAML:-/opt/digital_slide_archive/devops/dsa/provision.yaml}
+      CELERY_BROKER_URL: amqp://guest:guest@rabbitmq/
+      CELERY_RESULT_BACKEND: rpc://guest:guest@rabbitmq/
+      TMPDIR:
+      # See comments about authorizing docker repositories above
+      # DOCKER_CONFIG: /.docker
+    restart: unless-stopped
+    volumes:
+      # Needed to use slicer_cli_web to run docker containers
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Modify the worker.local.cfg to specify a different rabbitmq server and
+      # then enable this mount.  On the rabbitmq server, make sure you add a
+      # non-guest default user and use that both in the worker and in the main
+      # girder settings.
+      # - ./worker.local.cfg:/opt/girder_worker/girder_worker/worker.local.cfg
+      # Allow overriding the start command
+      - ./start_worker.sh:/opt/digital_slide_archive/devops/dsa/start_worker.sh
+      # Needed to allow transferring data to slicer_cli_web docker containers
+      - ${TMPDIR:-/tmp}:${TMPDIR:-/tmp}
+
+      # See comments about authorizing docker repositories above
+      # - /home/<user directory>/.docker:/.docker:ro
+
+      # Add additional mounts here to get access to existing files on your
+      # system if they have the same path as on the girder container.
+    depends_on:
+      - rabbitmq
+    command: /opt/digital_slide_archive/devops/dsa/start_worker.sh
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"
+    healthcheck:
+      test: ["CMD", "celery", "-b", "amqp://rabbitmq:5672", "inspect", "ping"]
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/devops/ver5/logs/.gitignore
+++ b/devops/ver5/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/devops/ver5/provision.py
+++ b/devops/ver5/provision.py
@@ -1,0 +1,766 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+import yaml
+
+logger = logging.getLogger(__name__)
+# See http://docs.python.org/3.3/howto/logging.html#configuring-logging-for-a-library
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+def get_collection_folder(adminUser, collName, folderName):
+    from girder.models.collection import Collection
+    from girder.models.folder import Folder
+
+    if Collection().findOne({'lowerName': collName.lower()}) is None:
+        logger.info('Create collection %s', collName)
+        Collection().createCollection(collName, adminUser)
+    collection = Collection().findOne({'lowerName': collName.lower()})
+    if Folder().findOne({
+            'parentId': collection['_id'], 'lowerName': folderName.lower()}) is None:
+        logger.info('Create folder %s in %s', folderName, collName)
+        Folder().createFolder(collection, folderName, parentType='collection',
+                              public=True, creator=adminUser)
+    folder = Folder().findOne({'parentId': collection['_id'], 'lowerName': folderName.lower()})
+    return folder
+
+
+def get_sample_data(adminUser, collName='Sample Images', folderName='Images'):
+    """
+    As needed, download sample data.
+
+    :param adminUser: a user to create and modify collections and folders.
+    :param collName: the collection name where the data will be added.
+    :param folderName: the folder name where the data will be added.
+    :returns: the folder where the sample data is located.
+    """
+    try:
+        import girder_client
+        import requests
+        import urllib3
+    except ImportError:
+        logger.error('girder_client is unavailable.  Cannot get sample data.')
+        return
+    from girder.models.item import Item
+    from girder.models.upload import Upload
+    from girder_large_image.models.image_item import ImageItem
+
+    folder = get_collection_folder(adminUser, collName, folderName)
+    remote = girder_client.GirderClient(apiUrl='https://data.kitware.com/api/v1')
+    session = requests.Session()
+    retries = urllib3.util.retry.Retry(
+        total=10, backoff_factor=0.1, status_forcelist=[104, 500, 502, 503, 504])
+    session.mount('http://', requests.adapters.HTTPAdapter(max_retries=retries))
+    session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
+    remote._session = session
+
+    remoteFolder = remote.resourceLookup('/collection/HistomicsTK/Deployment test images')
+    sampleItems = []
+    for remoteItem in remote.listItem(remoteFolder['_id']):
+        item = Item().findOne({'folderId': folder['_id'], 'name': remoteItem['name']})
+        if item and len(list(Item().childFiles(item, limit=1))):
+            sampleItems.append(item)
+            continue
+        if not item:
+            item = Item().createItem(remoteItem['name'], creator=adminUser, folder=folder)
+        for remoteFile in remote.listFile(remoteItem['_id']):
+            with tempfile.NamedTemporaryFile() as tf:
+                fileName = tf.name
+                tf.close()
+                logger.info('Downloading %s', remoteFile['name'])
+                remote.downloadFile(remoteFile['_id'], fileName)
+                Upload().uploadFromFile(
+                    open(fileName, 'rb'), os.path.getsize(fileName),
+                    name=remoteItem['name'], parentType='item',
+                    parent=item, user=adminUser)
+        sampleItems.append(item)
+    for item in sampleItems:
+        if 'largeImage' not in item:
+            logger.info('Making large_item %s', item['name'])
+            try:
+                ImageItem().createImageItem(item, createJob=False)
+            except Exception:
+                pass
+            logger.info('done')
+    return folder
+
+
+def value_from_resource(value, adminUser):
+    """
+    If a value is a string that startwith 'resource:', it is a path to an
+    existing resource.  Fetch it an return the string of the _id.
+
+    :param value: a value
+    :returns: the original value it is not a resource, or the string id of the
+        resource.
+    """
+    import girder.utility.path as path_util
+    from girder.models.assetstore import Assetstore
+
+    starts = {'resource:': 'doc', 'resourceid:': 'id', 'resourceobjid:': 'obj'}
+    if isinstance(value, dict):
+        value = {k: value_from_resource(v, adminUser) for k, v in value.items()}
+    for start, stype in starts.items():
+        if str(value).startswith(start):
+            resPath = value.split(':', 1)[1]
+            if resPath == 'admin':
+                resource = adminUser
+            elif resPath.startswith('assetstore/'):
+                resource = Assetstore().findOne({'name': value.split('/', 1)[1]})
+            else:
+                resource = path_util.lookUpPath(resPath, force=True)['document']
+            logger.info(f'Finding {start} reference for {resPath} as '
+                        f'{resource["_id"] if resource else resource}')
+            if stype == 'doc':
+                value = resource
+            elif stype == 'id':
+                value = str(resource['_id'])
+            else:
+                value = resource['_id']
+            break
+    return value
+
+
+def provision_resources(resources, adminUser):
+    """
+    Given a dictionary of resources, add them to the system.  The resource is
+    only added if a resource of that name with the same parent object does not
+    exist.
+
+    :param resources: a list of resources to add.
+    :param adminUser: the admin user to use for provisioning.
+    """
+    from girder.utility.model_importer import ModelImporter
+
+    for entry in resources:
+        entry = {k: value_from_resource(v, adminUser) for k, v in entry.items()}
+        modelName = entry.pop('model')
+        metadata = entry.pop('metadata', None)
+        metadata_update = entry.pop('metadata_update', True)
+        metadata_key = entry.pop('metadata_key', 'meta')
+        attrs = entry.pop('attrs', None)
+        attrs_update = entry.pop('attrs_update', True)
+        model = ModelImporter.model(modelName)
+        key = 'name' if model != 'user' else 'login'
+        query = {}
+        if key in entry:
+            query[key] = entry[key]
+        owners = {'folder': 'parent', 'item': 'folder', 'file': 'item'}
+        ownerKey = owners.get(modelName)
+        if ownerKey and ownerKey in entry and isinstance(
+                entry[ownerKey], dict) and '_id' in entry[ownerKey]:
+            query[ownerKey + 'Id'] = entry[ownerKey]['_id']
+        if query and model.findOne(query):
+            result = model.findOne(query)
+            logger.debug('Has %s (%r)', modelName, entry)
+        else:
+            createFunc = getattr(model, 'create%s' % modelName.capitalize())
+            logger.info('Creating %s (%r)', modelName, entry)
+            result = createFunc(**entry)
+            attrs_update = True
+        if isinstance(metadata, dict) and hasattr(model, 'setMetadata'):
+            if metadata_key not in metadata or metadata_update:
+                if metadata_key not in result:
+                    result[metadata_key] = {}
+                result[metadata_key].update(metadata.items())
+                for key in metadata:
+                    if metadata[key] is None:
+                        del result[metadata_key][key]
+                model.validateKeys(result[metadata_key])
+                result = model.save(result)
+        if attrs and attrs_update:
+            result.update(attrs)
+            result = model.save(result)
+
+
+def wait_for_job(gc, job):
+    """
+    Wait for a job to complete.
+
+    :param gc: the girder client.
+    :param job: a girder job.
+    :return: the updated girder job.
+    """
+    lastdot = time.time()
+    dotfreq = 1
+    jobId = job['_id']
+    while job['status'] not in (3, 4, 5):
+        if time.time() - lastdot >= dotfreq:
+            logger.debug('.')
+            lastdot += dotfreq
+        time.sleep(0.25)
+        job = gc.get('job/%s' % jobId)
+    if job['status'] == 3:
+        logger.debug(' done')
+    else:
+        logger.error(' failed')
+        raise Exception('Failed in job')
+    return job
+
+
+def get_slicer_images(imageList, adminUser, alwaysPull=False):
+    """
+    Load a list of cli docker images into the system.
+
+    :param imageList: a list of docker images.
+    :param adminUser: an admin user for permissions.
+    :param alwaysPull: true to ask to always pull the latest image.
+    """
+    import girder_client
+    from girder.models.token import Token
+
+    imageList = [entry for entry in imageList if entry and len(entry)]
+    if not len(imageList):
+        return
+    logger.info('Pulling and installing slicer_cli images: %r', imageList)
+    token = Token().createToken(user=adminUser)
+    gc = None
+    start = time.time()
+    while gc is None and time.time() - start < 60:
+        try:
+            gc = girder_client.GirderClient(apiUrl='http://localhost:8080/api/v1')
+        except Exception:
+            time.sleep(0.25)
+    gc.token = token
+    job = gc.put('slicer_cli_web/docker_image', data={
+        'name': json.dumps(imageList),
+        'pull': 'true' if alwaysPull else 'false',
+    })
+    wait_for_job(gc, job)
+
+
+def pip_install(packages):
+    """
+    Pip install a list of packages via the shell pip install command.  This
+    first tries installing all of the packages in a single command; if it
+    fails, they are tried individually to betetr show where the failure occurs.
+
+    :param packages: a list of strings to add to the end of the pip install
+        command.
+    """
+    if not packages or not len(packages):
+        return
+    cmd = 'pip install -q ' + ' '.join(packages)
+    logger.info('Installing: %s', cmd)
+    try:
+        subprocess.check_call(cmd, shell=True)
+    except Exception:
+        logger.error(f'Failed to run {cmd}; trying pip install individually.')
+        for entry in packages:
+            cmd = 'pip install %s' % entry
+            logger.info('Installing: %s', cmd)
+            try:
+                subprocess.check_call(cmd, shell=True)
+            except Exception:
+                logger.error(f'Failed to run {cmd}')
+                raise
+
+
+def preprovision(opts):
+    """
+    Preprovision the instance.  This includes installing python modules with
+    pip.
+
+    :param opts: the argparse options.
+    """
+    pip_install(getattr(opts, 'pip', None))
+    if getattr(opts, 'shell', None) and len(opts.shell):
+        for entry in opts.shell:
+            cmd = entry
+            logger.info('Running: %s', cmd)
+            try:
+                subprocess.check_call(cmd, shell=True)
+            except Exception:
+                logger.error(f'Failed to run {cmd}')
+                raise
+
+
+def clean_delete_locks():
+    from girder.constants import AssetstoreType
+    from girder.models.assetstore import Assetstore
+
+    for assetstore in Assetstore().find():
+        if assetstore['type'] != AssetstoreType.FILESYSTEM:
+            continue
+        rootpath = assetstore['root']
+        cmd = ['find', rootpath, '-name', '*.deleteLock', '-delete']
+        logger.info(f'Removing old delete locks: {cmd}')
+        try:
+            subprocess.check_call(cmd, shell=False)
+        except Exception:
+            logger.info(f'Failed trying to remove old delete locks: {cmd}')
+
+
+def provision(opts):
+    """
+    Provision the instance.
+
+    :param opts: the argparse options.
+    """
+    from girder.models.assetstore import Assetstore
+    from girder.models.setting import Setting
+    from girder.models.user import User
+
+    # If there is are no admin users, create an admin user
+    if User().findOne({'admin': True}) is None:
+        adminParams = dict({
+            'login': 'admin',
+            'password': 'password',
+            'firstName': 'Admin',
+            'lastName': 'Admin',
+            'email': 'admin@nowhere.nil',
+            'public': True,
+        }, **(opts.admin if opts.admin else {}))
+        User().createUser(admin=True, **adminParams)
+    adminUser = User().findOne({'admin': True})
+
+    # Make sure we have an assetstore
+    assetstoreParams = opts.assetstore or {'name': 'Assetstore', 'root': '/assetstore'}
+    if not isinstance(assetstoreParams, list):
+        assetstoreParams = [assetstoreParams]
+    if Assetstore().findOne() is None:
+        for params in assetstoreParams:
+            method = params.pop('method', 'createFilesystemAssetstore')
+            getattr(Assetstore(), method)(**params)
+
+    # Clean up old deleteLocks
+    if getattr(opts, 'clean-delete-locks', None):
+        clean_delete_locks()
+
+    # Make sure we have a demo collection and download some demo files
+    if getattr(opts, 'samples', None):
+        get_sample_data(
+            adminUser,
+            getattr(opts, 'sample-collection', 'Samples'),
+            getattr(opts, 'sample-folder', 'Images'))
+    if opts.resources:
+        provision_resources(opts.resources, adminUser)
+    settings = dict({}, **(opts.settings or {}))
+    force = getattr(opts, 'force', None) or []
+    for key, value in settings.items():
+        if (value != '__SKIP__' and (
+                force is True or key in force or
+                Setting().get(key) is None or
+                Setting().get(key) == Setting().getDefault(key))):
+            value = value_from_resource(value, adminUser)
+            logger.info('Setting %s to %r', key, value)
+            try:
+                Setting().set(key, value)
+            except Exception:
+                logger.error('Failed to set %s', key)
+
+
+def postprovision(opts):
+    """
+    Postrovision the instance.
+
+    :param opts: the argparse options.
+    """
+    from girder.models.user import User
+
+    adminUser = User().findOne({'admin': True})
+    images = []
+    if getattr(opts, 'slicer-cli-image-pull', None):
+        images = list(dict.fromkeys(getattr(opts, 'slicer-cli-image-pull', None)))
+        try:
+            get_slicer_images(getattr(opts, 'slicer-cli-image-pull', None),
+                              adminUser, alwaysPull=True)
+        except Exception:
+            logger.info('Cannot fetch and pull slicer-cli-images.')
+            logger.exception('Cannot fetch and pull slicer-cli-images.')
+    if getattr(opts, 'slicer-cli-image', None):
+        images = [image for image in dict.fromkeys(getattr(opts, 'slicer-cli-image', None))
+                  if image not in images]
+        try:
+            get_slicer_images(images, adminUser)
+        except Exception:
+            logger.info('Cannot fetch slicer-cli-images.')
+
+
+def preprovision_worker(opts):
+    """
+    Preprovision the worker.
+    """
+    settings = dict({}, **(opts.worker or {}))
+    pip_install(settings.get('pip'))
+    if settings.get('shell') and len(settings['shell']):
+        for entry in settings['shell']:
+            cmd = entry
+            logger.info('Running: %s', cmd)
+            try:
+                subprocess.check_call(cmd, shell=True)
+            except Exception:
+                logger.error(f'Failed to run {cmd}')
+                raise
+
+
+def provision_worker(opts):
+    """
+    Provision the worker.  There are a few top-level settings, but others
+    should be in the worker sub-field.
+    """
+    settings = dict({}, **(opts.worker or {}))
+    for key in dir(opts):
+        if key.startswith('worker-'):
+            mainkey = key.split('worker-', 1)[1]
+            if settings.get(mainkey) is None:
+                settings[mainkey] = getattr(opts, key)
+    if not settings.get('rabbitmq-host'):
+        return
+    conf = configparser.ConfigParser()
+    conf.read([settings['config']])
+    conf.set('celery', 'broker', 'amqp://%s:%s@%s/' % (
+        settings['rabbitmq-user'], settings['rabbitmq-pass'], settings['host']))
+    conf.set('celery', 'backend', 'rpc://%s:%s@%s/' % (
+        settings['rabbitmq-user'], settings['rabbitmq-pass'], settings['host']))
+    with open(settings['config'], 'w') as fptr:
+        conf.write(fptr)
+
+
+def merge_environ_opts(opts):
+    """
+    Merge environment options, overriding other settings.
+
+    :param opts: the options parsed from the command line.
+    :return opts: the modified options.
+    """
+    keyDict = {
+        'RABBITMQ_USER': 'worker_rabbitmq_user',
+        'RABBITMQ_PASS': 'worker_rabbitmq_pass',
+        'DSA_RABBITMQ_HOST': 'worker_rabbitmq_host',
+    }
+    for key, value in os.environ.items():
+        if not value or not value.strip():
+            continue
+        if key == 'DSA_WORKER_API_URL':
+            key = 'worker.api_url'
+        elif key.startswith('DSA_SETTING_'):
+            key = key.split('DSA_SETTING_', 1)[1]
+        elif key in keyDict:
+            key = keyDict[key]
+        else:
+            continue
+        opts.settings[key] = value
+        if not opts.force:
+            opts.force = {key}
+        elif opts.force is not True:
+            opts.force = set(opts.force)
+            opts.force.add(key)
+    return opts
+
+
+def merge_yaml_opts(opts, parser):
+    """
+    Parse a yaml file of provisioning options.  Modify the options used for
+    provisioning.
+
+    :param opts: the options parsed from the command line.
+    :param parser: command line parser used to check if the options are the
+        default values.
+    :return opts: the modified options.
+    """
+    yamlfile = os.environ.get('DSA_PROVISION_YAML') if getattr(
+        opts, 'yaml', None) is None else opts.yaml
+    if yamlfile:
+        logger.debug('Parse yaml file: %r', yamlfile)
+    if not yamlfile or not os.path.exists(yamlfile):
+        return opts
+    defaults = parser.parse_args(args=[])
+    if getattr(opts, 'use-defaults', None) is not False:
+        defaults = merge_default_opts(defaults)
+    yamlopts = yaml.safe_load(open(yamlfile).read())
+    for key, value in yamlopts.items():
+        key = key.replace('_', '-')
+        if getattr(opts, key, None) is None or getattr(
+                opts, key, None) == getattr(defaults, key, None):
+            if key == 'settings' and getattr(opts, key, None) and isinstance(value, dict):
+                getattr(opts, key).update(value)
+            else:
+                setattr(opts, key, value)
+    logger.debug('Arguments after adding yaml: %r', opts)
+    return opts
+
+
+def merge_default_opts(opts):
+    """
+    Add the defaults to the options.
+
+    :param opts: the options parsed from the command line.
+    :return opts: the modified options.
+    """
+    settings = dict({}, **(opts.settings or {}))
+    settings.update({
+        'worker.api_url': 'http://girder:8080/api/v1',
+        'worker.direct_path': True,
+        'core.brand_name': 'Digital Slide Archive',
+        'core.http_only_cookies': True,
+        'histomicsui.webroot_path': 'histomics',
+        'histomicsui.alternate_webroot_path': 'histomicstk',
+        'histomicsui.delete_annotations_after_ingest': True,
+        'homepage.markdown': """# Digital Slide Archive
+---
+## Bioinformatics Platform
+
+Welcome to the **Digital Slide Archive**.
+
+Developers who want to use the Girder REST API should check out the
+[interactive web API docs](api/v1).
+
+The [HistomicsUI](histomics) application is enabled.""",
+        'slicer_cli_web.task_folder': 'resourceid:collection/Tasks/Slicer CLI Web Tasks',
+    })
+    opts.settings = settings
+    if getattr(opts, 'slicer-cli-image-pull', None) is None:
+        setattr(opts, 'slicer-cli-image-pull', ['dsarchive/histomicstk:latest'])
+    if getattr(opts, 'assetstore', None) is None:
+        opts.assetstore = {
+            'name': 'Assetstore',
+            'root': '/assetstore',
+            'method': 'createFilesystemAssetstore',
+        }
+    if getattr(opts, 'admin', None) is None:
+        opts.admin = {
+            'login': 'admin',
+            'password': 'password',
+            'firstName': 'Admin',
+            'lastName': 'Admin',
+            'email': 'admin@nowhere.nil',
+            'public': True,
+        }
+    if getattr(opts, 'clean-delete-locks', None) is None:
+        setattr(opts, 'clean-delete-locks', True)
+    resources = opts.resources or []
+    resources.extend([{
+        'model': 'collection',
+        'name': 'Tasks',
+        'creator': 'resource:admin',
+        'public': True,
+    }, {
+        'model': 'folder',
+        'parent': 'resource:collection/Tasks',
+        'parentType': 'collection',
+        'name': 'Slicer CLI Web Tasks',
+        'creator': 'resource:admin',
+        'public': True,
+    }])
+    opts.resources = resources
+    return opts
+
+
+class YamlAction(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        """Parse a yaml entry"""
+        if nargs is not None:
+            raise ValueError('nargs not allowed')
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, yaml.safe_load(values))
+
+
+if __name__ == '__main__':  # noqa
+    parser = argparse.ArgumentParser(description='Provision a Digital Slide Archive instance')
+    parser.add_argument(
+        '--force', action='store_true',
+        help='Reset all settings.  This does not change the admin user or the '
+        'default assetstore if those already exist.  Otherwise, settings are '
+        'only added or modified if they do not exist or are the default '
+        'value.')
+    parser.add_argument(
+        '--samples', '--data', '--sample-data',
+        action='store_true', help='Download sample data')
+    parser.add_argument(
+        '--clean-delete-locks', action='store_true',
+        help='Remove assetstore delete locks on start')
+    parser.add_argument(
+        '--no-clean-delete-locks', action='store_false',
+        dest='clean-delete-locks',
+        help='Do not remove assetstore delete locks on start')
+    parser.add_argument(
+        '--sample-collection', dest='sample-collection', default='Samples',
+        help='Sample data collection name')
+    parser.add_argument(
+        '--sample-folder', dest='sample-folder', default='Images',
+        help='Sample data folder name')
+    parser.add_argument(
+        '--admin', action=YamlAction,
+        help='A yaml dictionary of parameters used to create a default admin '
+        'user.  If any of login, password, firstName, lastName, email, or '
+        'public are not specified, some default values are used.  If any '
+        'admin user already exists, no modifications are made.')
+    parser.add_argument(
+        '--assetstore', action=YamlAction,
+        help='A yaml dictionary (or list of dictionaries) of parameters used '
+        'to create a default assetstore.  This can include "method" which '
+        'includes the creation method, such as "createFilesystemAssetstore" '
+        'or "createS3Assetstore".  Otherwise, this is a list of parameters '
+        'passed to the creation method.  For filesystem assetstores, these '
+        'parameters are name, root, and perms.  For S3 assetstores, these are '
+        'name, bucket, accessKeyId, secret, prefix, service, readOnly, '
+        'region, inferCredentials, and serverSideEncryption.  If unspecified, '
+        'a filesystem assetstore is created.')
+    parser.add_argument(
+        '--settings', action=YamlAction,
+        help='A yaml dictionary of settings to change in the Girder '
+        'database.  This is merged with the default settings dictionary.  '
+        'Settings are only changed if they are their default values, the '
+        'force option is used, or they are specified by an environment '
+        'variable.  If a setting has a value of "__SKIP__", it will not be '
+        'changed (this can prevent setting a default setting '
+        'option to any value).')
+    parser.add_argument(
+        '--resources', action=YamlAction,
+        help='A yaml list of resources to add by name to the Girder '
+        'database.  Each entry is a dictionary including "model" with the '
+        'resource model and a dictionary of values to pass to the '
+        'appropriate create(resource) function.  A value of '
+        '"resource:<path>" is converted to the resource document with that '
+        'resource path.  "resource:admin" uses the default admin, '
+        '"resourceid:<path>" is the string id for the resource path.')
+    parser.add_argument(
+        '--yaml',
+        help='Specify parameters for this script in a yaml file.  If no value '
+        'is specified, this defaults to the environment variable of '
+        'DSA_PROVISION_YAML.  No error is thrown if the file does not exist. '
+        'The yaml file is a dictionary of keys as would be passed to the '
+        'command line.')
+    parser.add_argument(
+        '--no-mongo-compat', action='store_false', dest='mongo-compat',
+        default=True, help='Do not automatically set the mongo feature '
+        'compatibility version to the current server version.')
+    parser.add_argument(
+        '--no-defaults', action='store_false', dest='use-defaults',
+        default=None, help='Do not use default settings; start with a minimal '
+        'number of parameters.')
+    parser.add_argument(
+        '--pip', action='append', help='A list of modules to pip install.  If '
+        'any are specified that include girder client plugins, also add a '
+        'shell task to build those plugins.  Each specified value is passed '
+        'to pip install directly, so additional options are needed, these can '
+        'be added (such as --find-links).  The actual values need to be '
+        'escaped appropriately for a bash shell.')
+    parser.add_argument(
+        '--slicer-cli-image', dest='slicer-cli-image', action='append',
+        help='Install slicer_cli images, only pulling if not present.')
+    parser.add_argument(
+        '--slicer-cli-image-pull', dest='slicer-cli-image-pull', action='append',
+        help='Install slicer_cli images, always pulling the latest.')
+
+    parser.add_argument(
+        '--rabbitmq-user', default='guest', dest='worker-rabbitmq-user',
+        help='Worker: RabbitMQ user name.')
+    parser.add_argument(
+        '--rabbitmq-pass', default='guest', dest='worker-rabbitmq-pass',
+        help='Worker: RabbitMQ password.')
+    parser.add_argument(
+        '--rabbitmq-host', dest='worker-rabbitmq-host',
+        help='Worker: RabbitMQ host.')
+    parser.add_argument(
+        '--config', dest='worker-config',
+        default='/opt/girder_worker/girder_worker/worker.local.cfg',
+        help='Worker: Path to the worker config file.')
+    parser.add_argument(
+        '--worker', action=YamlAction,
+        help='A yaml dictionary of worker settings.')
+    parser.add_argument(
+        '--worker-main', dest='portion', action='store_const',
+        const='worker-main',
+        help='Provision a worker, not the main process.')
+    parser.add_argument(
+        '--worker-pre', dest='portion', action='store_const',
+        const='worker-pre',
+        help='Pre-provision a worker, not the main process.')
+    parser.add_argument(
+        '--pre', dest='portion', action='store_const', const='pre',
+        help='Only do preprovisioning (install optional python modules).')
+    parser.add_argument(
+        '--main', dest='portion', action='store_const', const='main',
+        help='Only do main provisioning.')
+    parser.add_argument(
+        '--post', dest='portion', action='store_const', const='post',
+        help='Only do postprovisioning (add slicer_cli_web tasks).')
+    parser.add_argument(
+        '--verbose', '-v', action='count', default=0, help='Increase verbosity')
+    parser.add_argument(
+        '--dry-run', '-n', dest='dry-run', action='store_true',
+        help='Report merged options but do not actually apply them')
+    opts = parser.parse_args(args=sys.argv[1:])
+    logger.addHandler(logging.StreamHandler(sys.stderr))
+    logger.setLevel(max(1, logging.WARNING - 10 * opts.verbose))
+    try:
+        logger.info('Provision file date: %s; size: %d',
+                    time.ctime(os.path.getmtime(__file__)),
+                    os.path.getsize(__file__))
+    except Exception:
+        pass
+    logger.debug('Parsed arguments: %r', opts)
+    if getattr(opts, 'use-defaults', None) is not False:
+        opts = merge_default_opts(opts)
+    opts = merge_yaml_opts(opts, parser)
+    opts = merge_environ_opts(opts)
+    logger.debug('Merged arguments: %r', opts)
+    if getattr(opts, 'dry-run'):
+        print(yaml.dump({k: v for k, v in vars(opts).items() if v is not None}))
+        sys.exit(0)
+    # Worker provisioning
+    if getattr(opts, 'portion', None) == 'worker-pre':
+        preprovision_worker(opts)
+        sys.exit(0)
+    if getattr(opts, 'portion', None) == 'worker-main':
+        provision_worker(opts)
+        sys.exit(0)
+    if getattr(opts, 'portion', None) in {'pre', None}:
+        # Run provisioning that has to happen before configuring the server.
+        preprovision(opts)
+        if getattr(opts, 'portion', None) == 'pre':
+            sys.exit(0)
+    if getattr(opts, 'portion', None) in {'main', None}:
+        # This loads plugins, allowing setting validation.  We want the import
+        # to be after the preprovision step.
+        from girder import constants, plugin
+        from girder.utility.server import create_app
+
+        info = create_app(mode=os.environ.get(
+            'GIRDER_SERVER_MODE', constants.ServerMode.PRODUCTION))
+        plugin._loadPlugins(info)
+        if getattr(opts, 'mongo-compat', None) is not False:
+            from girder.models import getDbConnection
+
+            try:
+                db = getDbConnection()
+            except Exception:
+                logger.warning('Could not connect to mongo.')
+            try:
+                # In mongo shell, this is functionally
+                #   db.adminCommand({setFeatureCompatibilityVersion:
+                #     db.version().split('.').slice(0, 2).join('.')})
+                db.admin.command({'setFeatureCompatibilityVersion': '.'.join(
+                    db.server_info()['version'].split('.')[:2]), 'confirm': True})
+            except Exception:
+                try:
+                    db.admin.command({'setFeatureCompatibilityVersion': '.'.join(
+                        db.server_info()['version'].split('.')[:2])})
+                except Exception:
+                    logger.warning('Could not set mongo feature compatibility version.')
+            try:
+                # Also attempt to upgrade old version 2 image sources
+                db.girder.item.update_many(
+                    {'largeImage.sourceName': 'svs'},
+                    {'$set': {'largeImage.sourceName': 'openslide'}})
+            except Exception:
+                logger.warning('Could not update old source names.')
+        provision(opts)
+    if getattr(opts, 'portion', None) in {'post', None}:
+        # Run provisioning that has to happen before configuring the server.
+        postprovision(opts)
+        if getattr(opts, 'portion', None) == 'post':
+            sys.exit(0)

--- a/devops/ver5/provision.yaml
+++ b/devops/ver5/provision.yaml
@@ -1,0 +1,117 @@
+---
+# The provision script can take a yaml file with provision options
+
+# This is a dictionary of command-line arguments for the provisioning script
+# If force is True, set all settings even if they are already set.  This may
+# also be a list of settings keys to force.  It does not change the admin user
+# or the default assetstore if those already exist.  If False, settings are
+# only added or modified if they do not exist or are the default value.
+force: False
+samples: False
+clean-delete-locks: True
+sample-collection: Samples
+sample-folder: Images
+# Set use-defaults to False to skip default settings
+use-defaults: True
+# Set mongo_compat to False to not automatically set the mongo feature
+# compatibility version to the current server version.
+mongo-compat: True
+# A list of additional pip modules to install; if any are girder plugins with
+# client-side code, also specify rebuild-client.
+# pip:
+#   - girder-oauth
+#   - girder-ldap
+# rebuild-client may be False, True (for production mode), or "development"
+rebuild-client: False
+# Run additional shell commands before start
+# shell:
+#   - ls
+# Default admin user if there are no admin users
+admin:
+  login: admin
+  password: password
+  firstName: Admin
+  lastName: Admin
+  email: admin@nowhere.nil
+  public: True
+# Default assetstore if there are no assetstores
+assetstore:
+  method: createFilesystemAssetstore
+  name: Assetstore
+  root: /assetstore
+# Any resources to ensure exist.  A model must be specified.  This creates the
+# resource if there is no match for all specified values other than metadata
+# and attrs.  A value of "resource:<path>" is converted to the resource
+# document with that resource path.  "resourceid:<path>" is the string id for
+# the resource path, "resourceobjid:<path>" is the Mongo object id for the
+# resource path.  A <path> of "admin" uses the default admin user.  A <path> of
+# the form "assetstore/<name>" references the named assetstore.
+#   You can add metadata to a resource.  The default key is meta.  If
+# metadata_update is False, metadata will not be set if any metadata
+# already exists.
+#   You can alter the core model of a resource using the attrs key.  If the
+# resource already exists, this will only be applied if attrs_update is True.
+resources:
+  - model: collection
+    name: Tasks
+    creator: resource:admin
+    public: True
+  - model: folder
+    parent: resource:collection/Tasks
+    parentType: collection
+    name: "Slicer CLI Web Tasks"
+    creator: resource:admin
+    public: True
+    # metadata:
+    #   sample_key: sample_value
+    # metadata_key: meta
+    # metadata_update: True
+    # attrs:
+    #   quota:
+    #     preferredAssetstore: resource:assetstore/Assetstore
+    # attrs_update: True
+settings:
+  worker.broker: "amqp://guest:guest@rabbitmq"
+  worker.backend: "rpc://guest:guest@rabbitmq"
+  worker.api_url: "http://girder:8080/api/v1"
+  worker.direct_path: True
+  core.brand_name: "Digital Slide Archive"
+  # core.http_only_cookies: True
+  histomicsui.webroot_path: "histomics"
+  histomicsui.alternate_webroot_path: "histomicstk"
+  histomicsui.delete_annotations_after_ingest: True
+  homepage.markdown: |-
+    # Digital Slide Archive
+    ---
+    ## Bioinformatics Platform
+
+    Welcome to the **Digital Slide Archive**.
+
+    Developers who want to use the Girder REST API should check out the
+    [interactive web API docs](api/v1).
+
+    The [HistomicsUI](histomics) application is enabled.
+  slicer_cli_web.task_folder: "resourceid:collection/Tasks/Slicer CLI Web Tasks"
+# List slicer-cli-images to pull, if not present, and load
+# slicer-cli-image:
+#   - dsarchive/histomicstk:latest
+# List slicer-cli-images to always pull, and load
+slicer-cli-image-pull:
+  - dsarchive/histomicstk:latest
+# The worker can specify parameters for provisioning
+# worker-rabbitmq-host: girder:8080
+worker-rabbitmq-user: guest
+worker-rabbitmq-pass: guest
+worker-config: /opt/girder_worker/girder_worker/worker.local.cfg
+# These have precedence over the top level values
+worker:
+  # rabbitmq-host: girder:8080
+  # rabbitmq-user: guest
+  # rabbitmq-pass: guest
+  # config: /opt/girder_worker/girder_worker/worker.local.cfg
+  # Install additional pip packages in the worker
+  # pip:
+  #   - package_one
+  # Run additional shell commands in the worker before start
+  # shell:
+  #   - ls

--- a/devops/ver5/rabbitmq.advanced.config
+++ b/devops/ver5/rabbitmq.advanced.config
@@ -1,0 +1,1 @@
+[ {rabbit, [ {consumer_timeout, undefined} ]} ].

--- a/devops/ver5/start_girder.sh
+++ b/devops/ver5/start_girder.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Ensures that the main process runs as the DSA_USER and is part of both that
+# group and the docker group.  Fail if DSA_USER is not specified.
+if [[ -z "$DSA_USER" ]]; then
+  echo "Set the DSA_USER before starting (e.g, DSA_USER=\$$(id -u):\$$(id -g) <up command>"
+  exit 1
+fi
+# add a user with the DSA_USER's id; this user is named ubuntu if it doesn't
+# exist.
+adduser --uid ${DSA_USER%%:*} --disabled-password --gecos "" ubuntu 2>/dev/null
+# add a group with the DSA_USER's group id.
+addgroup --gid ${DSA_USER#*:} $(id -ng ${DSA_USER#*:}) 2>/dev/null
+# add the user to the user group.
+adduser $(id -nu ${DSA_USER%%:*}) $(getent group ${DSA_USER#*:} | cut "-d:" -f1) 2>/dev/null
+# add a group with the docker group id.
+addgroup --gid $(stat -c "%g" /var/run/docker.sock) docker 2>/dev/null
+# add the user to the docker group.
+adduser $(id -nu ${DSA_USER%%:*}) $(getent group $(stat -c "%g" /var/run/docker.sock) | cut "-d:" -f1) 2>/dev/null
+# Try to increase permissions for the docker socket; this helps this work on
+# OSX where the users don't translate
+chmod 777 /var/run/docker.sock 2>/dev/null || true
+# Use iptables to make some services appear as if they are on localhost (as
+# well as on the docker network).  This is done to allow tox tests to run.
+sysctl -w net.ipv4.conf.eth0.route_localnet=1
+iptables -t nat -A OUTPUT -o lo -p tcp -m tcp --dport 27017 -j DNAT --to-destination `dig +short mongodb`:27017
+iptables -t nat -A OUTPUT -o lo -p tcp -m tcp --dport 11211 -j DNAT --to-destination `dig +short memcached`:11211
+iptables -t nat -A POSTROUTING -o eth0 -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE
+echo 'PATH="/opt/digital_slide_archive/devops/dsa/utils:/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH"' >> /home/$(id -nu ${DSA_USER%%:*})/.bashrc
+echo ==== Pre-Provisioning ===
+PATH="/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH" \
+python /opt/digital_slide_archive/devops/dsa/provision.py -v --pre
+# Run subsequent commands as the DSA_USER.  This sets some paths based on what
+# is expected in the Docker so that the current python environment and the
+# devops/dsa/utils are available.  Then:
+# - Provision the Girder instance.  This sets values in the database, such as
+#   creating an admin user if there isn't one.  See the provision.py script for
+#   the details.
+# - If possible, set up a girder mount.  This allows file-like access of girder
+#   resources.  It requires the host to have fuse installed and the docker
+#   container to be run with enough permissions to use fuse.
+# - Start the main girder process.
+su $(id -nu ${DSA_USER%%:*}) -c "
+  PATH=\"/opt/digital_slide_archive/devops/dsa/utils:/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH\";
+  echo ==== Provisioning === &&
+  python /opt/digital_slide_archive/devops/dsa/provision.py -v --main &&
+  echo ==== Creating FUSE mount === &&
+  (girder mount ${DSA_GIRDER_MOUNT_OPTIONS%%:-} /fuse || true) &&
+  if [[ -f /tmp/girder_build.pid ]]; then
+  echo ==== Wait for girder build to finish === &&
+  while [[ -e /proc/$(cat /tmp/girder_build.pid) && ! -f /tmp/girder_build_done ]]; do sleep 0.1; done &&
+  true; fi &&
+  echo ==== Starting Girder === &&
+  # girder serve --host 0.0.0.0 2> >(tee -a /logs/error.log | tee -a /logs/info.log >&2) | tee -a /logs/info.log &
+  gunicorn girder.wsgi:app --bind=0.0.0.0:8080 --workers=4 --preload &
+  girder_pid=\$! &&
+  echo ==== Postprovisioning === &&
+  python /opt/digital_slide_archive/devops/dsa/provision.py -v --post &&
+  wait \${girder_pid}
+"

--- a/devops/ver5/start_worker.sh
+++ b/devops/ver5/start_worker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Ensures that the main process runs as the DSA_USER and is part of both that
+# group and the docker group.  Fail if DSA_USER is not specified.
+if [[ -z "$DSA_USER" ]]; then
+  echo "Set the DSA_USER before starting (e.g, DSA_USER=\$$(id -u):\$$(id -g) <up command>"
+  exit 1
+fi
+# add a user with the DSA_USER's id; this user is named ubuntu if it doesn't
+# exist.
+adduser --uid ${DSA_USER%%:*} --disabled-password --gecos "" ubuntu 2>/dev/null
+# add a group with the DSA_USER's group id.
+addgroup --gid ${DSA_USER#*:} $(id -ng ${DSA_USER#*:}) 2>/dev/null
+# add the user to the user group.
+adduser $(id -nu ${DSA_USER%%:*}) $(getent group ${DSA_USER#*:} | cut "-d:" -f1) 2>/dev/null
+# add a group with the docker group id.
+addgroup --gid $(stat -c "%g" /var/run/docker.sock) docker 2>/dev/null
+# add the user to the docker group.
+adduser $(id -nu ${DSA_USER%%:*}) $(getent group $(stat -c "%g" /var/run/docker.sock) | cut "-d:" -f1) 2>/dev/null
+# Try to increase permissions for the docker socket; this helps this work on
+# OSX where the users don't translate
+chmod 777 /var/run/docker.sock 2>/dev/null || true
+chmod 777 ${TMPDIR:-/tmp} || true
+echo ==== Pre-Provisioning ===
+python3 /opt/digital_slide_archive/devops/dsa/provision.py --worker-pre
+echo ==== Provisioning === &&
+python3 /opt/digital_slide_archive/devops/dsa/provision.py --worker-main
+echo ==== Starting Worker === &&
+# Run subsequent commands as the DSA_USER.  This sets some paths based on what
+# is expected in the Docker so that the current python environment and the
+# devops/dsa/utils are available.  Then it runs girder_worker
+su $(id -nu ${DSA_USER%%:*}) -c "
+  PATH=\"/opt/digital_slide_archive/devops/dsa/utils:/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH\";
+  DOCKER_CLIENT_TIMEOUT=86400 TMPDIR=${TMPDIR:-/tmp} GW_DIRECT_PATHS=true python -m girder_worker --concurrency=${DSA_WORKER_CONCURRENCY:-2} -Ofair --prefetch-multiplier=1
+"

--- a/dsa5.Dockerfile
+++ b/dsa5.Dockerfile
@@ -1,0 +1,235 @@
+FROM girder/tox-and-node
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
+
+ENV LANG=en_US.UTF-8
+
+# Install some additional packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    # For ease of running tox tests inside containers \
+    iptables \
+    dnsutils \
+    # Install some additional packages for convenience when testing \
+    bsdmainutils \
+    iputils-ping \
+    telnet-ssl \
+    tmux \
+    # For developer convenience \
+    nano \
+    jq \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    find / -xdev -name '*.py[oc]' -type f -exec rm {} \+ && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+
+
+# Install docker command line tools.  If docker is unavailable, this will do no
+# harm.  If the host system isn't ubuntu, this should still allow debug.
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null && \
+    ls -al /etc/apt/sources.list.d && \
+    cat /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    docker-ce-cli \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    find / -xdev -name '*.py[oc]' -type f -exec rm {} \+ && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+
+
+RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /usr/bin/tini && \
+    chmod +x /usr/bin/tini
+
+# Make a virtualenv with our preferred python
+RUN virtualenv --python 3.11 /opt/venv && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Make sure core packages are up to date
+RUN python --version && \
+    pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir -U tox wheel && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+
+
+RUN . ~/.bashrc && \
+    nvm install 22 && \
+    nvm alias default 22 && \
+    nvm use default && \
+    rdfind -minsize 32768 -makehardlinks true -makeresultsfile false /root/.nvm && \
+    nvm uninstall 14 && \
+    rm /usr/local/node && \
+    ln -s $(dirname `which npm`) /usr/local/node && \
+    npm config set fetch-timeout 600000 && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    true
+
+# Clone packages and pip install what we want to be local
+RUN cd /opt && \
+    # Install gunicorn so we can use it instead of girder serve \
+    pip install --no-cache-dir gunicorn && \
+    git clone -b v4-integration https://github.com/girder/girder && \
+    cd /opt/girder && \
+    pip install --no-cache-dir -e .[mount] && \
+    pip install --no-cache-dir -e clients/python && \
+    cd girder/web && \
+    npm ci && \
+    npx vite build --base=/ && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+RUN cd /opt/girder/worker && \
+    pip install --no-cache-dir -e . && \
+    \
+    cd /opt/girder/plugins/worker && \
+    pip install --no-cache-dir -e .[girder,worker] && \
+    cd girder_plugin_worker/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+# Girder plugins
+RUN true && \
+    cd /opt/girder/plugins/hashsum_download && \
+    pip install --no-cache-dir -e . && \
+    cd girder_hashsum_download/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/girder/plugins/homepage && \
+    pip install --no-cache-dir -e . && \
+    cd girder_homepage/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/girder/plugins/jobs && \
+    pip install --no-cache-dir -e . && \
+    cd girder_jobs/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/girder/plugins/ldap && \
+    pip install --no-cache-dir -e . && \
+    cd girder_ldap/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/girder/plugins/oauth && \
+    pip install --no-cache-dir -e . && \
+    cd girder_oauth/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/girder/plugins/user_quota && \
+    pip install --no-cache-dir -e . && \
+    cd girder_user_quota/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/girder/plugins/import_tracker && \
+    pip install --no-cache-dir -e . && \
+    cd girder_import_tracker/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    # virtual_folders has no web_client \
+    cd /opt/girder/plugins/virtual_folders && \
+    pip install --no-cache-dir -e . && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+# Girder worker
+RUN true && \
+    cd /opt/girder/worker && \
+    pip install --no-cache-dir -e . && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+RUN cd /opt/girder/plugins/slicer_cli_web && \
+    # pip install --no-cache-dir -e .[girder,worker] && \
+    pip install --no-cache-dir -e . && \
+    cd girder_slicer_cli_web/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+RUN cd /opt && \
+    git clone -b girder-5 https://github.com/girder/large_image && \
+    cd /opt/large_image && \
+    pip install --no-cache-dir --find-links https://girder.github.io/large_image_wheels -e .[memcached] -rrequirements-dev.txt && \
+    cd /opt/large_image/girder/girder_large_image/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/large_image/girder_annotation/girder_large_image_annotation/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    cd /opt/large_image/sources/dicom/large_image_source_dicom/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    rdfind -minsize 32768 -makehardlinks true -makeresultsfile false /opt/venv && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+RUN cd /opt && \
+    git clone -b girder-5 https://github.com/DigitalSlideArchive/HistomicsUI && \
+    cd /opt/HistomicsUI && \
+    # Unpin since we are using local installs \
+    sed -i 's/==1\.3.*'\''/'\''/g' setup.py && \
+    pip install --no-cache-dir -e .[analysis] && \
+    cd /opt/HistomicsUI/histomicsui/web_client && \
+    # This should be npm ci \
+    # npm install && \
+    npm ci && \
+    BUILD_TARGET=plugin npx vite build --base=/ && \
+    BUILD_TARGET=app npx vite build --base=/histomics/ && \
+    rdfind -minsize 32768 -makehardlinks true -makeresultsfile false /opt/venv && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+RUN cd /opt && \
+    git clone -b girder-5 https://github.com/DigitalSlideArchive/girder_assetstore && \
+    cd /opt/girder_assetstore && \
+    pip install --no-cache-dir -e . && \
+    cd /opt/girder_assetstore/girder_assetstore/web_client && \
+    npm ci && \
+    npx vite build --base=/ && \
+    find /opt -xdev -name node_modules -exec rm -rf {} \+ && \
+    rm -rf /root/.cache /root/.npm /tmp/* && \
+    find / -xdev -name __pycache__ -type d -exec rm -rf {} \+ && \
+    true
+
+# When running the worker, adjust some settings
+RUN echo 'task_reject_on_worker_lost = True' >> /opt/girder/worker/girder_worker/celeryconfig.py && \
+    echo 'task_acks_late = True' >> /opt/girder/worker/girder_worker/celeryconfig.py
+
+COPY . /opt/digital_slide_archive
+
+ENV PATH="/opt/digital_slide_archive/devops/dsa/utils:$PATH"
+
+WORKDIR /opt/HistomicsUI
+
+# add a variety of directories
+RUN mkdir -p /fuse --mode=a+rwx && \
+    mkdir /logs && \
+    mkdir /assetstore && \
+    mkdir /mounts --mode=a+rwx
+
+RUN cp /opt/digital_slide_archive/devops/dsa/utils/.vimrc ~/.vimrc
+
+ARG DSA_VERSIONS
+ENV DSA_VERSIONS="$DSA_VERSIONS"
+
+# Better shutdown signalling
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+CMD ["bash"]


### PR DESCRIPTION
This still needs documentation.  There is a Girder 5-based docker compose deployment in the devops/ver5 directory.

The very brief migration notes are:

- You must convert any customizations of the girder or girder worker config files to use environment variables.

- Girder logging will be different (currently, it is in the docker logs, not the info log).

- Although you should be able to switch between a Girder 5 and a Girder 3 base, this is not fully tested.

- If you are adding additional plugins in provisioning, the client build process now uses vite, not Girder build.

For now, the Girder 3 deployment is still the default.