### PR TITLE
Update some documentation for Girder 5.

### DIFF
--- a/devops/ver5/provision.yaml
+++ b/devops/ver5/provision.yaml
@@ -17,12 +17,10 @@ use-defaults: True
 # compatibility version to the current server version.
 mongo-compat: True
 # A list of additional pip modules to install; if any are girder plugins with
-# client-side code, also specify rebuild-client.
+# client-side code, that code must be built in the shell step
 # pip:
 #   - girder-oauth
 #   - girder-ldap
-# rebuild-client may be False, True (for production mode), or "development"
-rebuild-client: False
 # Run additional shell commands before start
 # shell:
 #   - ls

--- a/devops/ver5/start_girder.sh
+++ b/devops/ver5/start_girder.sh
@@ -51,7 +51,7 @@ su $(id -nu ${DSA_USER%%:*}) -c "
   true; fi &&
   echo ==== Starting Girder === &&
   # girder serve --host 0.0.0.0 2> >(tee -a /logs/error.log | tee -a /logs/info.log >&2) | tee -a /logs/info.log &
-  gunicorn girder.wsgi:app --bind=0.0.0.0:8080 --workers=4 --preload &
+  gunicorn --timeout 0 girder.wsgi:app --bind=0.0.0.0:8080 --workers=4 --preload &
   girder_pid=\$! &&
   echo ==== Postprovisioning === &&
   python /opt/digital_slide_archive/devops/dsa/provision.py -v --post &&

--- a/devops/ver5/start_worker.sh
+++ b/devops/ver5/start_worker.sh
@@ -30,5 +30,5 @@ echo ==== Starting Worker === &&
 # devops/dsa/utils are available.  Then it runs girder_worker
 su $(id -nu ${DSA_USER%%:*}) -c "
   PATH=\"/opt/digital_slide_archive/devops/dsa/utils:/opt/venv/bin:/.pyenv/bin:/.pyenv/shims:$PATH\";
-  DOCKER_CLIENT_TIMEOUT=86400 TMPDIR=${TMPDIR:-/tmp} GW_DIRECT_PATHS=true python -m girder_worker --concurrency=${DSA_WORKER_CONCURRENCY:-2} -Ofair --prefetch-multiplier=1
+  DOCKER_CLIENT_TIMEOUT=86400 TMPDIR=${TMPDIR:-/tmp} GW_DIRECT_PATHS=true celery -A girder_worker.app.app worker --concurrency=${DSA_WORKER_CONCURRENCY:-2} -Ofair --prefetch-multiplier=1
 "


### PR DESCRIPTION
In the Girder 5 beta, temporarily turn off gunicorn timeouts.

Run girder_worker as a celery module rather than importing and running Celery as girder_worker.  This should allow celery to use click to process environment variables.