### PR TITLE
Make periodic check only rebuild on changes

### DIFF
--- a/.circleci/check_updates.sh
+++ b/.circleci/check_updates.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+DEPENDENT_REPOS=(
+  "girder/girder/commits/master"
+  "girder/large_image/commits/master"
+  "DigitalSlideArchive/HistomicsUI/commits/master"
+
+  "girder/slicer_cli_web/commits/master"
+  "girder/girder_worker/commits/master"
+  "girder/girder_worker_utils/commits/master"
+  "DigitalSlideArchive/import-tracker/commits/main"
+
+  "girder/girder/commits/v4-integration"
+  "DigitalSlideArchive/girder_assetstore/commits/girder-5"
+)
+# girder_assetstore should be main branch once it is official
+
+
+LAST_COMMITS_FILE=".last_commits"
+
+GITHUB_TOKEN="${GITHUB_TOKEN}"
+
+get_latest_commit() {
+  local repo=$1
+  local api_url="https://api.github.com/repos/${repo}"
+  local headers=""
+  if [ -n "$GITHUB_TOKEN" ]; then
+    headers="-H 'Authorization: token ${GITHUB_TOKEN}'"
+  fi
+  curl -s $headers "$api_url" | jq -r '.sha'
+}
+
+if [ -f "$LAST_COMMITS_FILE" ]; then
+  source "$LAST_COMMITS_FILE"
+fi
+
+UPDATES_FOUND=false
+
+for repo in "${DEPENDENT_REPOS[@]}"; do
+  echo "Checking $repo..."
+  latest_commit=$(get_latest_commit "$repo")
+  last_commit_var="LAST_COMMIT_${repo//[\/ -]/_}" # Replace slashes with underscores
+  last_commit="${!last_commit_var}"
+
+  if [ "$latest_commit" != "$last_commit" ]; then
+    echo "Update found in $repo: $latest_commit (previous: $last_commit)"
+    UPDATES_FOUND=true
+    echo "$last_commit_var='$latest_commit'" >> "$LAST_COMMITS_FILE"
+  else
+    echo "No updates in $repo."
+  fi
+done
+
+if [ "$UPDATES_FOUND" = true ]; then
+  echo "Updates found, triggering build pipeline..."
+  curl -X POST \
+    -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"branch":"master"}' \
+    https://circleci.com/api/v2/project/github/DigitalSlideArchive/digital_slide_archive/pipeline
+else
+  echo "No updates found, skipping build."
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,23 @@ jobs:
       - run:
           name: Scan the local image with trivy; report low and medium vulnerabilities, but don't fail
           command: trivy image --scanners vuln image --input /tmp/workspace/dsa_common.tar --exit-code 0 --severity LOW,MEDIUM,UNKNOWN --no-progress
+  check-for-updates:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - last-commits-{{ .Branch }}-{{ .Environment.CIRCLECI_WORKFLOW_ID }}
+            - last-commits-{{ .Branch }} # Fallback to the most recent cache for the branch
+      - run:
+          name: Check for updates in dependent repos
+          command: |
+            ./.circleci/check_updates.sh
+      - save_cache:
+          paths:
+            - .last_commits
+          key: last-commits-{{ .Branch }}-{{ .Environment.CIRCLECI_WORKFLOW_ID }}
 
 workflows:
   version: 2
@@ -482,47 +499,12 @@ workflows:
   periodic:
     triggers:
       - schedule:
-          # Run every Monday morning at 7 a.m.
-          cron: "0 7 * * 1"
+          # Run every morning at 7 a.m.
+          cron: "0 7 * * *"
           filters:
             branches:
               only:
                 - master
+                - check-updates
     jobs:
-      - docker-compose
-      - test-cli-common:
-          requires:
-            - docker-compose
-      - test-proxy-common:
-          requires:
-            - docker-compose
-      - test-girder-build-common:
-          requires:
-            - docker-compose
-      - test-histomicsui-common:
-          requires:
-            - docker-compose
-      - docker-compose-minimal
-      - docker-compose-with-dive-volview
-      - docker-compose-girder-5
-      - docker-compose-external-worker
-      - scan-docker:
-          requires:
-            - docker-compose
-      - docs
-      - publish-docker-common:
-          requires:
-            - docker-compose
-            - test-cli-common
-            - test-girder-build-common
-            - test-histomicsui-common
-            - test-proxy-common
-            - scan-docker
-      - publish-docker-common5:
-          requires:
-            - docker-compose-girder-5
-            # - test-cli-common
-            # - test-girder-build-common
-            # - test-histomicsui-common
-            # - test-proxy-common
-            # - scan-docker
+      - check-for-updates


### PR DESCRIPTION
This explicitly checks the github repos used in the docker build.  If we ever go a long time without updates to any of them, we'd want to do a check any way just to make sure all of the other dependencies and the trivy check still pass.