### PR TITLE
Improve version 5 docker compose

### DIFF
--- a/devops/ver5/docker-compose.yml
+++ b/devops/ver5/docker-compose.yml
@@ -35,10 +35,9 @@ services:
       GIRDER_SETTING_CORE_HTTP_ONLY_COOKIES: true
       GIRDER_SETTING_SERVER_MODE: production
       HISTOMICSUI_RESTRICT_DOWNLOADS: 100000
-      LARGE_IMAGE_CACHE_BACKEND: memcached
-      LARGE_IMAGE_CACHE_MEMCACHED_URL: memcached
-      LARGE_IMAGE_CACHE_MEMCACHED_PASSWORD: None
-      LARGE_IMAGE_CACHE_MEMCACHED_USERNAME: None
+      LARGE_IMAGE_CACHE_BACKEND: redis
+      LARGE_IMAGE_CACHE_REDIS_URL: redis:6379
+      # LARGE_IMAGE_CACHE_REDIS_PASSWORD: ''
       LARGE_IMAGE_CACHE_TILESOURCE_MAXIMUM: 64
       # Mount options can be used to, for instance, add diskcache (e.g.,
       #  "-o diskcache,diskcache_size_limit=2147483648")
@@ -68,7 +67,7 @@ services:
       - ./logs:/logs
     depends_on:
       - mongodb
-      - memcached
+      - redis
       - rabbitmq
     command: /opt/digital_slide_archive/devops/dsa/start_girder.sh
     # logging:
@@ -103,23 +102,6 @@ services:
         max-file: "5"
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-      interval: 5m
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-  memcached:
-    image: memcached
-    command: -m 4096 --max-item-size 8M
-    restart: unless-stopped
-    # Uncomment to allow access to memcached from outside of the docker network
-    # ports:
-    #   - "11211"
-    logging:
-      options:
-        max-size: "10M"
-        max-file: "5"
-    healthcheck:
-      test: ["CMD", "bash", "-c", 'exec 3<>/dev/tcp/localhost/11211; printf "stats\nquit\n" >&3; cat <&3']
       interval: 5m
       timeout: 10s
       retries: 3
@@ -192,6 +174,19 @@ services:
         max-file: "5"
     healthcheck:
       test: ["CMD", "celery", "-b", "amqp://rabbitmq:5672", "inspect", "ping"]
+      interval: 5m
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+  redis:
+    image: redis
+    command: ["redis-server", "--maxmemory", "4096MB"]
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "ping"]
       interval: 5m
       timeout: 10s
       retries: 3

--- a/devops/ver5/docker-compose.yml
+++ b/devops/ver5/docker-compose.yml
@@ -70,10 +70,10 @@ services:
       - redis
       - rabbitmq
     command: /opt/digital_slide_archive/devops/dsa/start_girder.sh
-    # logging:
-    #   options:
-    #     max-size: "10M"
-    #     max-file: "5"
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/system/version"]
       interval: 5m
@@ -181,6 +181,7 @@ services:
   redis:
     image: redis
     command: ["redis-server", "--maxmemory", "4096MB"]
+    restart: unless-stopped
     logging:
       options:
         max-size: "10M"
@@ -191,3 +192,16 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+  logging:
+    image: python:3.13-slim
+    user: ${DSA_USER:-PLEASE SET DSA_USER}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./logs:/logs
+      - ./start_dockerlog.py:/app/start_dockerlog.py
+    command: ["bash", "-c", "export PYTHONUSERBASE=/tmp && pip install --user docker && python -u /app/start_dockerlog.py"]
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "10M"
+        max-file: "5"

--- a/devops/ver5/start_dockerlog.py
+++ b/devops/ver5/start_dockerlog.py
@@ -1,0 +1,69 @@
+#!/usr/env/bin/ python3
+
+import datetime
+import logging.handlers
+import os
+import threading
+import time
+
+import docker
+
+LOG_DIR = '/logs'
+LOG_SIZE = 10 * 1024 ** 2
+LOG_COUNT = 6
+
+
+def get_compose_services(client, network):
+    containers = client.containers.list()
+    service_map = {}
+    for c in containers:
+        if network not in c.attrs['NetworkSettings']['Networks'].keys():
+            continue
+        labels = c.attrs.get('Config', {}).get('Labels', {})
+        if 'com.docker.compose.service' in labels:
+            svc = labels['com.docker.compose.service']
+            if svc != 'logging':
+                service_map[svc] = c
+    return service_map
+
+
+def start_logging(service, container):
+    print(f'Starting logs for {service}')
+    log_file = os.path.join(LOG_DIR, f'{service if service != "girder" else "info"}.log')
+    logger = logging.getLogger(service)
+    logger.addHandler(logging.handlers.RotatingFileHandler(
+        log_file, maxBytes=LOG_SIZE, backupCount=LOG_COUNT))
+    logger.setLevel(logging.INFO)
+    logger.info('=' * 78)
+    logger.info(f'Starting {service} container log: {datetime.datetime.now().isoformat()}')
+    logger.info('=' * 78)
+    try:
+        for line in container.logs(stream=True, follow=True):
+            logger.info(line.decode().rstrip())
+    except Exception as exc:
+        print(f'Stopped logging {service}: {exc}')
+
+
+def get_container_network_name(client):
+    container_id = os.getenv('HOSTNAME')
+    container = client.containers.get(container_id)
+    network_names = list(container.attrs['NetworkSettings']['Networks'].keys())
+    return network_names[0]
+
+
+def main():
+    print('Starting log tracker')
+    client = docker.from_env(version='auto')
+    network = get_container_network_name(client)
+    procs = {os.getenv('HOSTNAME'): True}
+    while True:
+        services = get_compose_services(client, network)
+        for svc, c in services.items():
+            if svc not in procs:
+                procs[svc] = threading.Thread(
+                    target=start_logging, args=(svc, c), daemon=True).start()
+        time.sleep(5)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This switches from memcached to redis, as we want redis for better notifications.

This adds a docker container for persistent logging to a stable location.  This reduces the surprise when switching from girder 3.  Since docker doesn't persist logs across container removal, this does.  Newly added is the ability to persist mongo and rabbitmq logs, allowing a local install to be better debugged if something goes wrong.  Naturally, this wouldn't be used in the minimal configuration or with terraform deployments.