### PR TITLE
Check more components for rebuilding images

### DIFF
--- a/.circleci/check_updates.py
+++ b/.circleci/check_updates.py
@@ -27,6 +27,7 @@ DEPENDENT_REPOS = [
 
     # both
     'girder/large_image_wheels/branches/gh-pages',
+    'OpenGeoscience/geojs/branches/master',
 ]
 
 


### PR DESCRIPTION
We check a variety of components we control to determine if we should do a rebuild of the images.  Add geojs to the list.